### PR TITLE
Implement uploading from non-seekable stream and follow-symlink

### DIFF
--- a/BreakingChanges.txt
+++ b/BreakingChanges.txt
@@ -1,4 +1,9 @@
+Tracking Breaking Changes since 0.6.6
+
+  - Changed to throwing out exception instead of starting a new transfer when resuming a transfer from or to a stream.
+
 Tracking Breaking Changes since 0.6.1
+
   - Changed the TransferException format, the TransferException with following 2 error codes won't expose inner exception details (e.g. RequestId) in TransferException message any more
     - UncategorizedException
     - FailToVadlidateDestination

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Microsoft Azure Storage Data Movement Library (0.6.6)
+# Microsoft Azure Storage Data Movement Library (0.7.0)
 
 The Microsoft Azure Storage Data Movement Library designed for high-performance uploading, downloading and copying Azure Storage Blob and File. This library is based on the core data movement framework that powers [AzCopy](https://azure.microsoft.com/documentation/articles/storage-use-azcopy/).
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 2017.12.22 Version 0.7.0
- * All Services on both platforms
+ * All Services on both .Net Framework and .Net Core
    - Added support of uploading from non-seekable, non-fixed sized stream to block blob or append blob
    - Added support of uploading from non-seekable stream to page blob, azure file
    - Added error reporting about DataMovement Library doesn't support resuming of transferring from or to a stream 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,14 @@
+2017.12.22 Version 0.7.0
+ * All Services on both platforms
+   - Added support of uploading from non-seekable, non-fixed sized stream to block blob or append blob
+   - Added support of uploading from non-seekable stream to page blob, azure file
+   - Added error reporting about DataMovement Library doesn't support resuming of transferring from or to a stream 
+ * All Services on .Net Core
+   - Added support of transferring directory with symlinked subdirectories on Unix/Linux platforms
+ * Blob Service on .Net Core
+   - Fixed issue of not escaping '/' correctly when using character other than '/' as delimiter when downloading from a blob directory
+   - Fixed issue of not escaping continuous '/' in destination name correctly when downloading from a blob directory 
+
 2017.12.15 Version 0.6.6
  * Blob Service
    - Small file transfer optimization. Use put blob to upload block blob when blob size is small than 4MB to save request and optimize performance.

--- a/lib/ChunkedMemoryStream.cs
+++ b/lib/ChunkedMemoryStream.cs
@@ -39,6 +39,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1725:ParameterNamesShouldMatchBaseDeclaration", MessageId = "1#")]
         public override long Seek(long offset, SeekOrigin seekOrigin)
         {
             var newPos = 0;
@@ -69,6 +70,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             throw new NotImplementedException();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1725:ParameterNamesShouldMatchBaseDeclaration", MessageId = "0#")]
         public override int Read(byte[] toBuffer, int offset, int count)
         {
             if (toBuffer == null)
@@ -126,6 +128,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             return bytesReaded;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1725:ParameterNamesShouldMatchBaseDeclaration", MessageId = "0#")]
         public override void Write(byte[] fromBuffer, int offset, int count)
         {
             if (fromBuffer == null)

--- a/lib/Exceptions/TransferErrorCode.cs
+++ b/lib/Exceptions/TransferErrorCode.cs
@@ -102,6 +102,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         SubTransferFails = 18,
 
         /// <summary>
+        /// The source file size is invalid for azure file.
+        /// </summary>
+        UploadFileSourceFileSizeInvalid = 19,
+
+        /// <summary>
         /// Uncategorized transfer error.
         /// </summary>
         Unknown = 32,

--- a/lib/MD5HashStream.cs
+++ b/lib/MD5HashStream.cs
@@ -308,6 +308,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                         bytesToRead,
                         cancellationToken);
 
+                    totalBytesRead += bytesRead;
                     if (bytesRead < bytesToRead)
                     {
                         // No data anymore
@@ -320,8 +321,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                         currentChunk++;
                         currentChunkOffset = 0;
                     }
-
-                    totalBytesRead += bytesRead;
                     count -= bytesRead;
                 }
                 return totalBytesRead;

--- a/lib/MD5HashStream.cs
+++ b/lib/MD5HashStream.cs
@@ -50,6 +50,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// </summary>
         private long md5hashOffset;
 
+        private bool canSeek = true;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MD5HashStream"/> class.
         /// </summary>
@@ -91,10 +93,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             if (!this.stream.CanSeek)
             {
-                throw new NotSupportedException(string.Format(
-                    CultureInfo.CurrentCulture,
-                    Resources.StreamMustSupportSeekException,
-                    "Stream"));
+                canSeek = false;
+
+                if (!this.finishedSeparateMd5Calculator)
+                {
+                    throw new NotSupportedException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.StreamMustSupportSeekException,
+                        "Stream"));
+                }
             }
         }
 
@@ -225,7 +232,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             try
             {
-                this.stream.Position = readOffset;
+                if (canSeek)
+                {
+                    this.stream.Position = readOffset;
+                }
                 
                 return await this.stream.ReadAsync(
                     buffer,
@@ -261,7 +271,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             try
             {
-                this.stream.Position = readOffset;
+                if (canSeek)
+                {
+                    this.stream.Position = readOffset;
+                }
 
                 var currentChunk = 0;
                 var currentChunkOffset = 0;
@@ -334,7 +347,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             try
             {
-                this.stream.Position = writeOffset;
+                if (canSeek)
+                {
+                    this.stream.Position = writeOffset;
+                }
+
                 await this.stream.WriteAsync(
                     buffer,
                     offset,
@@ -368,7 +385,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             try
             {
-                this.stream.Position = writeOffset;
+                if (canSeek)
+                {
+                    this.stream.Position = writeOffset;
+                }
 
                 //TODO: Duplication of code
                 var currentChunk = 0;
@@ -634,7 +654,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             try
             {
-                this.stream.Position = readOffset;
+                if (canSeek)
+                {
+                    this.stream.Position = readOffset;
+                }
+
                 int readBytes = this.stream.Read(buffer, offset, count);
 
                 return readBytes;

--- a/lib/MemoryManager.cs
+++ b/lib/MemoryManager.cs
@@ -28,7 +28,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             long capacity, int bufferSize)
         {
             BufferSize = bufferSize;
-            long currentCapacity = capacity;
+            this.currentCapacity = capacity;
             long availableCells = capacity / bufferSize;
 
             int cellNumber = (int)Math.Min((long)Constants.MemoryManagerCellsMaximum, availableCells);

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -500,6 +500,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
         internal static string RestartableLogCorrupted {
             get {
                 return ResourceManager.GetString("RestartableLogCorrupted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resuming transfer from or to a stream is not supported. .
+        /// </summary>
+        internal static string ResumeStreamTransferNotSupported {
+            get {
+                return ResourceManager.GetString("ResumeStreamTransferNotSupported", resourceCulture);
             }
         }
         

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -10,7 +10,7 @@
 
 namespace Microsoft.WindowsAzure.Storage.DataMovement {
     using System;
-    using System.Reflection;
+    
     
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -19,7 +19,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -39,7 +39,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.WindowsAzure.Storage.DataMovement.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.WindowsAzure.Storage.DataMovement.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -84,6 +84,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
         internal static string AsyncCopyFromFileToPageBlobNotSupportException {
             get {
                 return ResourceManager.GetString("AsyncCopyFromFileToPageBlobNotSupportException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AzureFile.
+        /// </summary>
+        internal static string AzureFile {
+            get {
+                return ResourceManager.GetString("AzureFile", resourceCulture);
             }
         }
         
@@ -531,11 +540,29 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Source might be changed by other process or application..
+        /// </summary>
+        internal static string SourceChangedException {
+            get {
+                return ResourceManager.GetString("SourceChangedException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Source does not exist..
         /// </summary>
         internal static string SourceDoesNotExistException {
             get {
                 return ResourceManager.GetString("SourceDoesNotExistException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Source must be fixed size when destination is {0}.
+        /// </summary>
+        internal static string SourceMustBeFixedSize {
+            get {
+                return ResourceManager.GetString("SourceMustBeFixedSize", resourceCulture);
             }
         }
         

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -174,6 +174,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
         internal static string CloudFileSizeTooLargeException {
             get {
                 return ResourceManager.GetString("CloudFileSizeTooLargeException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Potential dead loop in directory structure due to symbolic link {0} with target to {1}.
+        /// </summary>
+        internal static string DeadLoop {
+            get {
+                return ResourceManager.GetString("DeadLoop", resourceCulture);
             }
         }
         

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -225,6 +225,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to enumerate directory {0}..
+        /// </summary>
+        internal static string EnumerateDirectoryException {
+            get {
+                return ResourceManager.GetString("EnumerateDirectoryException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to allocate required memory..
         /// </summary>
         internal static string FailedToAllocateMemoryException {

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -693,6 +693,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to load a dll, this might because the disk where the specific dll is located is not mounted with exec permission..
+        /// </summary>
+        internal static string UnableToLoadDLL {
+            get {
+                return ResourceManager.GetString("UnableToLoadDLL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The transfer failed..
         /// </summary>
         internal static string UncategorizedException {

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -693,7 +693,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to load a dll, this might because the disk where the specific dll is located is not mounted with exec permission..
+        ///   Looks up a localized string similar to Unable to load a dll, this might because the target dll is located on a disk without exec permission..
         /// </summary>
         internal static string UnableToLoadDLL {
             get {

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -310,6 +310,9 @@ MD5 in property: {2}</value>
   <data name="TransferEntryCopyIdCannotBeNullOrEmptyException" xml:space="preserve">
     <value>TransferEntry.CopyId cannot be null or empty because we need it to verify we are monitoring the right blob copying process.</value>
   </data>
+  <data name="UnableToLoadDLL" xml:space="preserve">
+    <value>Unable to load a dll, this might because the disk where the specific dll is located is not mounted with exec permission.</value>
+  </data>
   <data name="UnsupportedBlobTypeException" xml:space="preserve">
     <value>The given blob type {0} is not supported.</value>
     <comment>{0} is the given blob type.</comment>

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -311,7 +311,7 @@ MD5 in property: {2}</value>
     <value>TransferEntry.CopyId cannot be null or empty because we need it to verify we are monitoring the right blob copying process.</value>
   </data>
   <data name="UnableToLoadDLL" xml:space="preserve">
-    <value>Unable to load a dll, this might because the disk where the specific dll is located is not mounted with exec permission.</value>
+    <value>Unable to load a dll, this might because the target dll is located on a disk without exec permission.</value>
   </data>
   <data name="UnsupportedBlobTypeException" xml:space="preserve">
     <value>The given blob type {0} is not supported.</value>

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -345,6 +345,10 @@ MD5 in property: {2}</value>
     <value>Failed to enumerate directory {0} with file pattern {1}.</value>
     <comment>{0} is the directory path, {1} is file pattern.</comment>
   </data>
+  <data name="EnumerateDirectoryException" xml:space="preserve">
+    <value>Failed to enumerate directory {0}.</value>
+    <comment>{0} is the directory path.</comment>
+  </data>
   <data name="FailedToValidateDestinationException" xml:space="preserve">
     <value>Failed to validate destination.</value>
   </data>

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -162,6 +162,10 @@ MD5 calculated: {1}
 MD5 in property: {2}</value>
     <comment>{0} is the uri of source, {1} is the calculated MD5, {2} is the MD5 stored in the source property</comment>
   </data>
+  <data name="DeadLoop" xml:space="preserve">
+    <value>Potential dead loop in directory structure due to symbolic link {0} with target to {1}</value>
+    <comment>{0} is path of symbolic link, {1} is target of the symbolic link.</comment>
+  </data>
   <data name="DestinationBlobTypeNotMatch" xml:space="preserve">
     <value>User specified blob type does not match the blob type of the existing destination blob.</value>
   </data>

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -204,6 +204,10 @@ MD5 in property: {2}</value>
     <value>Blob type '{0}' is not supported.</value>
     <comment>{0} is the blob type name.</comment>
   </data>
+  <data name="SourceMustBeFixedSize" xml:space="preserve">
+    <value>Source must be fixed size when destination is {0}</value>
+    <comment>{0} is the is the destination blob type.</comment>
+  </data>
   <data name="OverwriteCallbackCancelTransferException" xml:space="preserve">
     <value>Skiped file "{0}" because target "{1}" already exists.</value>
     <comment>{0} is source file name, {1} is destination file name.</comment>
@@ -271,6 +275,9 @@ MD5 in property: {2}</value>
   <data name="SourceAndDestinationLocationCannotBeEqualException" xml:space="preserve">
     <value>Source and destination cannot be the same.</value>
   </data>
+  <data name="SourceChangedException" xml:space="preserve">
+    <value>Source might be changed by other process or application.</value>
+  </data>
   <data name="SourceDoesNotExistException" xml:space="preserve">
     <value>Source does not exist.</value>
   </data>
@@ -318,6 +325,9 @@ MD5 in property: {2}</value>
   </data>
   <data name="PageBlob" xml:space="preserve">
     <value>PageBlob</value>
+  </data>
+  <data name="AzureFile" xml:space="preserve">
+    <value>AzureFile</value>
   </data>
   <data name="SyncCopyFromUriToAzureBlobNotSupportedException" xml:space="preserve">
     <value>Copying from uri to Azure Blob Storage synchronously is not supported.</value>

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -376,4 +376,7 @@ MD5 in property: {2}</value>
     <value>File {0} is too long, relative path must not exceed 1024 characters. </value>
     <comment>{0} is the relative path of the file which exceed the 1024 characters limit.</comment>
   </data>
+  <data name="ResumeStreamTransferNotSupported" xml:space="preserve">
+    <value>Resuming transfer from or to a stream is not supported. </value>
+  </data>
 </root>

--- a/lib/TransferControllers/TransferReaders/StreamedReader.cs
+++ b/lib/TransferControllers/TransferReaders/StreamedReader.cs
@@ -393,6 +393,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
         private void ReadingDataHandler(ReadDataState asyncState, bool endofStream)
         {
             this.Controller.CheckCancellation();

--- a/lib/TransferControllers/TransferReaders/StreamedReader.cs
+++ b/lib/TransferControllers/TransferReaders/StreamedReader.cs
@@ -219,7 +219,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             {
                 this.SharedTransferData.TotalLength = this.inputStream.Length;
             }
-            catch (Exception)
+            catch (NotSupportedException)
             {
                 this.SharedTransferData.TotalLength = -1;
             }

--- a/lib/TransferControllers/TransferReaders/StreamedReader.cs
+++ b/lib/TransferControllers/TransferReaders/StreamedReader.cs
@@ -232,7 +232,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             if (checkpoint.TransferWindow.Any())
             {
                 // The size of last block can be smaller than BlockSize.
-                this.readLength -= checkpoint.EntryTransferOffset - checkpoint.TransferWindow.Last();
+                this.readLength -= Math.Min(checkpoint.EntryTransferOffset - checkpoint.TransferWindow.Last(), this.SharedTransferData.BlockSize);
                 this.readLength -= (checkpoint.TransferWindow.Count - 1) * this.SharedTransferData.BlockSize;
             }
 

--- a/lib/TransferControllers/TransferReaders/StreamedReader.cs
+++ b/lib/TransferControllers/TransferReaders/StreamedReader.cs
@@ -457,24 +457,19 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                 }
 
                 this.state = State.Finished;
-                try
+                if (!this.md5HashStream.SucceededSeparateMd5Calculator)
                 {
-                    if (!this.md5HashStream.SucceededSeparateMd5Calculator)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    var md5 = this.md5HashStream.MD5HashTransformFinalBlock();
-                    this.SharedTransferData.Attributes = new Attributes()
-                    {
-                        ContentMD5 = md5,
-                        OverWriteAll = false
-                    };
-                }
-                finally
+                var md5 = this.md5HashStream.MD5HashTransformFinalBlock();
+                this.CloseOwnStream();
+
+                this.SharedTransferData.Attributes = new Attributes()
                 {
-                    this.CloseOwnStream();
-                }
+                    ContentMD5 = md5,
+                    OverWriteAll = false
+                };
             }
         }
 

--- a/lib/TransferControllers/TransferWriters/AppendBlobWriter.cs
+++ b/lib/TransferControllers/TransferWriters/AppendBlobWriter.cs
@@ -339,11 +339,9 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                                 needToCheckContent = true;
                                 catchedStorageException = se;
                             }
-
-                            if (needToCheckContent &&
-                                (!await this.ValidateUploadedChunkAsync(transferData.MemoryBuffer, currentOffset, (long)transferData.Length)))
+                            else
                             {
-                                throw new InvalidOperationException(Resources.DestinationChangedException);
+                                throw;
                             }
                         }
 

--- a/lib/TransferControllers/TransferWriters/BlockBlobWriter.cs
+++ b/lib/TransferControllers/TransferWriters/BlockBlobWriter.cs
@@ -250,7 +250,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             if (checkpoint.TransferWindow.Any())
             {
                 // The size of last block can be smaller than BlockSize.
-                this.uploadedLength -= checkpoint.EntryTransferOffset - checkpoint.TransferWindow.Last();
+                this.uploadedLength -= Math.Min(checkpoint.EntryTransferOffset - checkpoint.TransferWindow.Last(), this.SharedTransferData.BlockSize);
                 this.uploadedLength -= (checkpoint.TransferWindow.Count - 1) * this.SharedTransferData.BlockSize;
             }
 

--- a/lib/TransferControllers/TransferWriters/CloudFileWriter.cs
+++ b/lib/TransferControllers/TransferWriters/CloudFileWriter.cs
@@ -44,6 +44,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
         protected override void CheckInputStreamLength(long inputStreamLength)
         {
+            if (inputStreamLength < 0)
+            {
+                throw new TransferException(
+                    TransferErrorCode.UploadFileSourceFileSizeInvalid,
+                    string.Format(CultureInfo.CurrentCulture, Resources.SourceMustBeFixedSize, Resources.AzureFile));
+            }
+
             if (inputStreamLength > Constants.MaxCloudFileSize)
             {
                 string exceptionMessage = string.Format(

--- a/lib/TransferControllers/TransferWriters/PageBlobWriter.cs
+++ b/lib/TransferControllers/TransferWriters/PageBlobWriter.cs
@@ -52,6 +52,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
         protected override void CheckInputStreamLength(long inputStreamLength)
         {
+            if (inputStreamLength < 0)
+            {
+                throw new TransferException(
+                    TransferErrorCode.UploadBlobSourceFileSizeInvalid,
+                    string.Format(CultureInfo.CurrentCulture, Resources.SourceMustBeFixedSize, Resources.PageBlob));
+            }
+
             if (0 != inputStreamLength % PageBlobPageSize)
             {
                 string exceptionMessage = string.Format(

--- a/lib/TransferEnumerators/AzureNameResolver.cs
+++ b/lib/TransferEnumerators/AzureNameResolver.cs
@@ -80,7 +80,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
             // 1) Unescape original string, original string is UrlEncoded.
             // 2) Replace Azure directory separator with Windows File System directory separator.
             // 3) Trim spaces at the end of the file name.
-            string destinationRelativePath = EscapeInvalidCharacters(this.TranslateDelimiters(sourceEntry.RelativePath).TrimEnd(new char[] { ' ' }));
+            string destinationRelativePath = this.TranslateDelimiters(sourceEntry.RelativePath);
+            if (Interop.CrossPlatformHelpers.IsWindows)
+            {
+                destinationRelativePath = destinationRelativePath.TrimEnd(new char[] { ' ' });
+            }
+
+            destinationRelativePath = EscapeInvalidCharacters(destinationRelativePath);
 
             // Split into path + filename parts.
             int lastSlash = destinationRelativePath.LastIndexOf(this.DirSeparator, StringComparison.Ordinal);

--- a/lib/TransferEnumerators/AzureNameResolver.cs
+++ b/lib/TransferEnumerators/AzureNameResolver.cs
@@ -75,6 +75,16 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
             get;
         }
 
+#if DOTNET5_4
+        protected char Delimiter
+        {
+            get
+            {
+                return this.delimiter;
+            }
+        }
+#endif
+        
         public string ResolveName(TransferEntry sourceEntry)
         {
             // 1) Unescape original string, original string is UrlEncoded.

--- a/lib/TransferEnumerators/AzureToFileNameResolver.cs
+++ b/lib/TransferEnumerators/AzureToFileNameResolver.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
         /// This is used to escape the first "/" or "/" following a "/".
         /// Like to escape "/abc///ac" to "%2Fabc/%2F%2Fac"
         /// </summary>
-        private static Regex escapeDirSeparators = new Regex("^/|(?<=/)/|$/");
+        private static Regex escapeDirSeparators = new Regex("^/|(?<=/)/|/$");
 #endif
 
         public AzureToFileNameResolver(char? delimiter)

--- a/lib/TransferEnumerators/AzureToFileNameResolver.cs
+++ b/lib/TransferEnumerators/AzureToFileNameResolver.cs
@@ -9,6 +9,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
     using System.Collections.Generic;
     using System.IO;
     using Interop;
+    using System.Globalization;
+    using System.Text.RegularExpressions;
 
     /// <summary>
     /// Name resolver class for translating Azure file/blob names to Windows file names.
@@ -24,6 +26,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
         /// Chars invalid for path name.
         /// </summary>
         private static char[] invalidPathChars = AzureToFileNameResolver.GetInvalidPathChars();
+
+#if DOTNET5_4
+        /// <summary>
+        /// This is used to escape the first "/" or "/" following a "/".
+        /// Like to escape "/abc///ac" to "%2Fabc/%2F%2Fac"
+        /// </summary>
+        private static Regex escapeDirSeparators = new Regex("^/|(?<=/)/|$/");
+#endif
 
         public AzureToFileNameResolver(char? delimiter)
             : base(delimiter)
@@ -57,6 +67,33 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
         {
             return Path.Combine(folder, name);
         }
+
+#if DOTNET5_4
+        protected override string TranslateDelimiters(string source)
+        {
+            if (!CrossPlatformHelpers.IsWindows
+                && this.Delimiter != '/')
+            {
+                source = source.Replace("/", "%2F");
+            }
+
+            return base.TranslateDelimiters(source);
+        }
+
+        protected override string EscapeInvalidCharacters(string fileName)
+        {
+            fileName = base.EscapeInvalidCharacters(fileName);
+
+            if (!CrossPlatformHelpers.IsWindows)
+            {
+                return escapeDirSeparators.Replace(fileName, "%2F");
+            }
+            else
+            {
+                return fileName;
+            }
+        }
+#endif
 
         private static char[] GetInvalidPathChars()
         {

--- a/lib/TransferEnumerators/EnumerateDirectoryHelper.cs
+++ b/lib/TransferEnumerators/EnumerateDirectoryHelper.cs
@@ -13,8 +13,9 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
     using System.Security;
     using System.Threading;
     using Microsoft.WindowsAzure.Storage.DataMovement.Interop;
-
-#if !DOTNET5_4
+#if DOTNET5_4
+    using Mono.Unix;
+#else
     using System.Runtime.InteropServices;
 #endif
 
@@ -27,6 +28,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
     /// </summary>
     internal static class EnumerateDirectoryHelper
     {
+        internal class EnumerateFileEntryInfo
+        {
+            public string FileName { get; set; }
+            public FileAttributes FileAttributes { get; set; }
+            public string SymlinkTarget { get; set; }
+        };
+
         /// <summary>
         /// Returns the names of files (including their paths) in the specified directory that match the specified 
         /// search pattern, using a value to determine whether to search subdirectories.
@@ -42,6 +50,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
         /// <param name="searchOption">One of the values of the SearchOption enumeration that specifies whether 
         /// the search operation should include only the current directory or should include all subdirectories.
         /// The default value is TopDirectoryOnly.</param>
+        /// <param name="followsymlink">indicating whether to enumerate symlinked subdirectories.</param>
         /// <param name="cancellationToken">CancellationToken to cancel the method.</param>
         /// <returns>An enumerable collection of file names in the directory specified by path and that match 
         /// searchPattern and searchOption.</returns>
@@ -55,6 +64,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
             string searchPattern,
             string fromFilePath,
             SearchOption searchOption,
+            bool followsymlink,
             CancellationToken cancellationToken)
         {
             Utils.CheckCancellation(cancellationToken);
@@ -140,7 +150,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
             }
 
             Utils.CheckCancellation(cancellationToken);
-            return InternalEnumerateFiles(directoryName, filePattern, fromFilePath, searchOption, cancellationToken);
+            return InternalEnumerateFiles(directoryName, filePattern, fromFilePath, searchOption, followsymlink, cancellationToken);
         }
 
 #if TRANSPARENCY_V2
@@ -151,6 +161,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
             string filePattern,
             string fromFilePath,
             SearchOption searchOption,
+            bool followsymlink,
             CancellationToken cancellationToken)
         {
             Stack<string> folders = new Stack<string>();
@@ -179,7 +190,21 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                 // Skip non-existent folders
                 if (!LongPathDirectory.Exists(folder))
                 {
+#if DOTNET5_4
+                    if (CrossPlatformHelpers.IsLinux)
+                    {
+                        if (!SymlinkedDirExists(folder))
+                        {
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        continue;
+                    }
+#else
                     continue;
+#endif
                 }
 
 #if CODE_ACCESS_SECURITY // Only accessible to fully trusted code in non-CAS models
@@ -211,6 +236,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                     // Ignore this folder if we have no right to discovery it.
                     continue;
                 }
+                catch (IOException ex)
+                {
+                    throw new TransferException(string.Format(CultureInfo.CurrentCulture, Resources.EnumerateDirectoryException, folder), ex);
+                }
 #endif // CODE_ACCESS_SECURITY
 
                 // Return all files contained directly in this folder (which occur after the continuationTokenFile)
@@ -231,13 +260,30 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                     {
                         Utils.CheckCancellation(cancellationToken);
 
-                        FileAttributes fileAttributes = FileAttributes.Normal;
-                        string fileName = null;
+                        EnumerateFileEntryInfo fileEntryInfo = null;
 
                         try
                         {
-                            fileName = LongPath.GetFileName(filePath);
-                            fileAttributes = LongPathFile.GetAttributes(filePath);
+#if DOTNET5_4
+                            if (CrossPlatformHelpers.IsLinux)
+                            {
+                                fileEntryInfo = GetFileEntryInfo(filePath);
+                            }
+                            else
+                            {
+                                fileEntryInfo = new EnumerateFileEntryInfo()
+                                {
+                                    FileName = LongPath.GetFileName(filePath),
+                                    FileAttributes = LongPathFile.GetAttributes(filePath)
+                                };
+                            }
+#else
+                            fileEntryInfo = new EnumerateFileEntryInfo()
+                            {
+                                FileName = LongPath.GetFileName(filePath),
+                                FileAttributes = LongPathFile.GetAttributes(filePath)
+                            };
+#endif
                         }
                         // Cross-plat file system accessibility settings may cause exceptions while
                         // retrieving attributes from inaccessible paths. These paths shold be skipped.
@@ -245,16 +291,16 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                         catch (IOException) { }
                         catch (UnauthorizedAccessException) { }
 
-                        if (fileName == null)
+                        if (null == fileEntryInfo)
                         {
                             continue;
                         }
 
-                        if (FileAttributes.Directory != (fileAttributes & FileAttributes.Directory))
+                        if (FileAttributes.Directory != (fileEntryInfo.FileAttributes & FileAttributes.Directory))
                         {
                             if (passedContinuationToken)
                             {
-                                yield return LongPath.Combine(folder, fileName);
+                                yield return LongPath.Combine(folder, fileEntryInfo.FileName);
                             }
                             else
                             {
@@ -262,21 +308,21 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                                 {
                                     if (!passedContinuationToken)
                                     {
-                                        if (string.Equals(fileName, continuationTokenFile, StringComparison.Ordinal))
+                                        if (string.Equals(fileEntryInfo.FileName, continuationTokenFile, StringComparison.Ordinal))
                                         {
                                             passedContinuationToken = true;
                                         }
                                     }
                                     else
                                     {
-                                        yield return LongPath.Combine(folder, fileName);
+                                        yield return LongPath.Combine(folder, fileEntryInfo.FileName);
                                     }
                                 }
                                 else
                                 {
                                     // Windows file system is case-insensitive; OSX and Linux are case-sensitive
                                     var comparison = CrossPlatformHelpers.IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-                                    int compareResult = string.Compare(fileName, continuationTokenFile, comparison);
+                                    int compareResult = string.Compare(fileEntryInfo.FileName, continuationTokenFile, comparison);
                                     if (compareResult < 0)
                                     {
                                         // Skip files prior to the continuation token file
@@ -287,7 +333,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
 
                                     if (compareResult > 0)
                                     {
-                                        yield return LongPath.Combine(folder, fileName);
+                                        yield return LongPath.Combine(folder, fileEntryInfo.FileName);
                                     }
                                 }
                             }
@@ -315,56 +361,91 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                     {
                         Utils.CheckCancellation(cancellationToken);
 
-                        FileAttributes fileAttributes = FileAttributes.Normal;
-                        string fileName = null;
+                        EnumerateFileEntryInfo fileEntryInfo = null;
 
                         try
                         {
-                            fileName = LongPath.GetFileName(filePath);
-                            fileAttributes = LongPathFile.GetAttributes(filePath);
+#if DOTNET5_4
+                            if (CrossPlatformHelpers.IsLinux)
+                            {
+                                fileEntryInfo = GetFileEntryInfo(filePath);
+                            }
+                            else
+                            {
+                                fileEntryInfo = new EnumerateFileEntryInfo()
+                                {
+                                    FileName = LongPath.GetFileName(filePath),
+                                    FileAttributes = LongPathFile.GetAttributes(filePath)
+                                };
+                            }
+#else
+                            fileEntryInfo = new EnumerateFileEntryInfo()
+                            {
+                                FileName = LongPath.GetFileName(filePath),
+                                FileAttributes = LongPathFile.GetAttributes(filePath)
+                            };
+#endif
                         }
                         // Cross-plat file system accessibility settings may cause exceptions while
                         // retrieving attributes from inaccessible paths. These paths shold be skipped.
                         catch (FileNotFoundException) { }
                         catch (IOException) { }
                         catch (UnauthorizedAccessException) { }
-
-                        if (fileName == null)
+                        
+                        if (null == fileEntryInfo)
                         {
                             continue;
                         }
 
-                        if (FileAttributes.Directory == (fileAttributes & FileAttributes.Directory) &&
-                            !fileName.Equals(@".") &&
-                            !fileName.Equals(@".."))
+                        if (FileAttributes.Directory == (fileEntryInfo.FileAttributes & FileAttributes.Directory) &&
+                            !fileEntryInfo.FileName.Equals(@".") &&
+                            !fileEntryInfo.FileName.Equals(@".."))
                         {
+                            bool toBeEnumerated = false;
+#if DOTNET5_4
+                            if (CrossPlatformHelpers.IsLinux)
+                            {
+                                toBeEnumerated = ToEnumerateTheSubDir(LongPath.Combine(folder, fileEntryInfo.FileName), fileEntryInfo, followsymlink);
+                            }
+
                             // TODO: Ignore junction point or not. Make it configurable.
-                            if (FileAttributes.ReparsePoint != (fileAttributes & FileAttributes.ReparsePoint))
+                            else if (FileAttributes.ReparsePoint != (fileEntryInfo.FileAttributes & FileAttributes.ReparsePoint))
+                            {
+#else
+                            // TODO: Ignore junction point or not. Make it configurable.
+                            if (FileAttributes.ReparsePoint != (fileEntryInfo.FileAttributes & FileAttributes.ReparsePoint))
+                            {
+                                
+#endif
+                                toBeEnumerated = true;
+                            }
+
+                            if (toBeEnumerated)
                             {
                                 if (passedSubfoler)
                                 {
-                                    currentFolderSubFolders.Push(LongPath.Combine(folder, fileName));
+                                    currentFolderSubFolders.Push(LongPath.Combine(folder, fileEntryInfo.FileName));
                                 }
                                 else
                                 {
                                     if (CrossPlatformHelpers.IsLinux)
                                     {
-                                        if (string.Equals(fileName, fromSubfolder, StringComparison.Ordinal))
+                                        if (string.Equals(fileEntryInfo.FileName, fromSubfolder, StringComparison.Ordinal))
                                         {
                                             passedSubfoler = true;
-                                            currentFolderSubFolders.Push(LongPath.Combine(folder, fileName));
+                                            currentFolderSubFolders.Push(LongPath.Combine(folder, fileEntryInfo.FileName));
                                         }
                                     }
                                     else
                                     {
                                         // Windows file system is case-insensitive; OSX and Linux are case-sensitive
                                         var comparison = CrossPlatformHelpers.IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-                                        int compareResult = string.Compare(fileName, fromSubfolder, comparison);
+                                        int compareResult = string.Compare(fileEntryInfo.FileName, fromSubfolder, comparison);
 
                                         if (compareResult >= 0)
                                         {
                                             passedSubfoler = true;
-                                            currentFolderSubFolders.Push(LongPath.Combine(folder, fileName));
+                                            currentFolderSubFolders.Push(LongPath.Combine(folder, fileEntryInfo.FileName));
 
                                             if (compareResult > 0)
                                             {
@@ -391,6 +472,86 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                 }
             }
         }
+
+#if DOTNET5_4
+        private static bool SymlinkedDirExists(string dirPath)
+        {
+            dirPath = dirPath.TrimEnd(Path.DirectorySeparatorChar);
+            UnixFileSystemInfo fileSystemInfo = UnixFileSystemInfo.GetFileSystemEntry(dirPath);
+            if (!fileSystemInfo.IsSymbolicLink)
+            {
+                return false;
+            }
+
+            UnixSymbolicLinkInfo symlinkInfo = fileSystemInfo as UnixSymbolicLinkInfo;
+            if (symlinkInfo.HasContents && symlinkInfo.GetContents().IsDirectory)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static EnumerateFileEntryInfo GetFileEntryInfo(string filePath)
+        {
+            EnumerateFileEntryInfo fileEntryInfo = new EnumerateFileEntryInfo()
+            {
+                FileName = LongPath.GetFileName(filePath),
+                FileAttributes = FileAttributes.Normal,
+                SymlinkTarget = null
+            };
+
+            UnixFileSystemInfo fileSystemInfo = UnixFileSystemInfo.GetFileSystemEntry(filePath);
+            if (fileSystemInfo.IsSymbolicLink)
+            {
+                fileEntryInfo.FileAttributes |= FileAttributes.ReparsePoint;
+                fileEntryInfo.SymlinkTarget = Path.GetFullPath(Path.Combine(GetParentPath(filePath), (fileSystemInfo as UnixSymbolicLinkInfo).ContentsPath));
+
+                UnixSymbolicLinkInfo symlinkInfo = fileSystemInfo as UnixSymbolicLinkInfo;
+        
+                if (symlinkInfo.HasContents && symlinkInfo.GetContents().IsDirectory)
+                {
+                    fileEntryInfo.FileAttributes |= FileAttributes.Directory;
+                }
+            }
+
+            if (fileSystemInfo.IsDirectory)
+            {
+                fileEntryInfo.FileAttributes |= FileAttributes.Directory;
+            }
+            return fileEntryInfo;
+        }
+
+        private static bool ToEnumerateTheSubDir(string dirPath, EnumerateFileEntryInfo fileEntryInfo, bool followSymlink)
+        {
+            if (FileAttributes.ReparsePoint != (fileEntryInfo.FileAttributes & FileAttributes.ReparsePoint))
+            {
+                return true;
+            }
+            else if (followSymlink)
+            {
+                string fullPath = Path.GetFullPath(dirPath);
+
+                if (fullPath.StartsWith(AppendDirectorySeparator(fileEntryInfo.SymlinkTarget)))
+                {
+                    throw new TransferException(string.Format(CultureInfo.CurrentCulture, Resources.DeadLoop, fullPath, fileEntryInfo.SymlinkTarget));
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string GetParentPath(string filePath)
+        {
+            if (filePath.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                filePath = filePath.Substring(0, filePath.Length - 1);
+            }
+            return Path.GetDirectoryName(filePath);
+        }
+#endif
 
         private static string AppendDirectorySeparator(string dir)
         {

--- a/lib/TransferEnumerators/FileEnumerator.cs
+++ b/lib/TransferEnumerators/FileEnumerator.cs
@@ -24,13 +24,17 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
 
         private FileListContinuationToken listContinuationToken;
 
+        private bool followSymlink;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FileEnumerator" /> class.
         /// </summary>
         /// <param name="location">Directory location.</param>
-        public FileEnumerator(DirectoryLocation location)
+        /// <param name="followsymlink">Indicating whether to enumerate symlinked subdirectories.</param>
+        public FileEnumerator(DirectoryLocation location, bool followSymlink)
         {
             this.location = location;
+            this.followSymlink = followSymlink;
         }
 
         /// <summary>
@@ -92,6 +96,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                     filePattern,
                     this.listContinuationToken == null ? null : this.listContinuationToken.FilePath,
                     searchOption,
+                    followSymlink,
                     cancellationToken);
             }
             catch (Exception ex)

--- a/lib/TransferEnumerators/FileEnumerator.cs
+++ b/lib/TransferEnumerators/FileEnumerator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
         /// Initializes a new instance of the <see cref="FileEnumerator" /> class.
         /// </summary>
         /// <param name="location">Directory location.</param>
-        /// <param name="followsymlink">Indicating whether to enumerate symlinked subdirectories.</param>
+        /// <param name="followSymlink">Indicating whether to enumerate symlinked subdirectories.</param>
         public FileEnumerator(DirectoryLocation location, bool followSymlink)
         {
             this.location = location;

--- a/lib/TransferJobs/StreamLocation.cs
+++ b/lib/TransferJobs/StreamLocation.cs
@@ -107,30 +107,5 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             return this.Stream.ToString();
         }
-
-        // Summary:
-        //     Determines whether the specified object is equal to the current stream location.
-        //
-        // Parameters:
-        //   obj:
-        //     The object to compare with the current stream location.
-        //
-        // Returns:
-        //     true if the specified object is equal to the current stream location; otherwise, false.
-        public override bool Equals(object obj)
-        {
-            return Object.ReferenceEquals(this, obj);
-        }
-
-        //
-        // Summary:
-        //     Returns the hash code for the transfer location.
-        //
-        // Returns:
-        //     A 32-bit signed integer hash code.
-        public override int GetHashCode()
-        {
-            return this.ToString().GetHashCode();
-        }
     }
 }

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -361,7 +361,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             DirectoryLocation sourceLocation = new DirectoryLocation(sourcePath);
             AzureFileDirectoryLocation destLocation = new AzureFileDirectoryLocation(destFileDir);
-            FileEnumerator sourceEnumerator = new FileEnumerator(sourceLocation, options.FollowSymlink);
+            FileEnumerator sourceEnumerator = new FileEnumerator(sourceLocation, null == options ? false : options.FollowSymlink);
             if (options != null)
             {
                 sourceEnumerator.SearchPattern = options.SearchPattern;

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -1324,6 +1324,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                 transfer = transferContext.Checkpoint.GetTransfer(sourceLocation, destLocation, transferMethod);
                 if (transfer != null)
                 {
+                    if (sourceLocation is StreamLocation || destLocation is StreamLocation)
+                    {
+                        throw new TransferException(Resources.ResumeStreamTransferNotSupported);
+                    }
+
                     // update transfer location information
                     UpdateTransferLocation(transfer.Source, sourceLocation);
                     UpdateTransferLocation(transfer.Destination, destLocation);

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -314,7 +314,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             DirectoryLocation sourceLocation = new DirectoryLocation(sourcePath);
             AzureBlobDirectoryLocation destLocation = new AzureBlobDirectoryLocation(destBlobDir);
-            FileEnumerator sourceEnumerator = new FileEnumerator(sourceLocation);
+            FileEnumerator sourceEnumerator = new FileEnumerator(sourceLocation, null != options? options.FollowSymlink : false);
             if (options != null)
             {
                 sourceEnumerator.SearchPattern = options.SearchPattern;
@@ -361,7 +361,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             DirectoryLocation sourceLocation = new DirectoryLocation(sourcePath);
             AzureFileDirectoryLocation destLocation = new AzureFileDirectoryLocation(destFileDir);
-            FileEnumerator sourceEnumerator = new FileEnumerator(sourceLocation);
+            FileEnumerator sourceEnumerator = new FileEnumerator(sourceLocation, options.FollowSymlink);
             if (options != null)
             {
                 sourceEnumerator.SearchPattern = options.SearchPattern;

--- a/lib/TransferOptions/UploadDirectoryOptions.cs
+++ b/lib/TransferOptions/UploadDirectoryOptions.cs
@@ -6,16 +6,40 @@
 namespace Microsoft.WindowsAzure.Storage.DataMovement
 {
     using Microsoft.WindowsAzure.Storage.Blob;
+    using Microsoft.WindowsAzure.Storage.DataMovement.Interop;
+    using System;
 
     /// <summary>
     /// Represents a set of options that may be specified for upload directory operation
     /// </summary>
     public sealed class UploadDirectoryOptions : DirectoryOptions
     {
+        private bool followSymlink = false;
         /// <summary>
         /// Gets or sets type of destination blob. This option takes effect only when uploading to Azure blob storage.
         /// If blob type is not specified, BlockBlob is used.
         /// </summary>
         public BlobType BlobType { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to follow symlinked directories. This option only works in Unix/Linux platforms.
+        /// </summary>
+        public bool FollowSymlink
+        {
+            get
+            {
+                return this.followSymlink;
+            }
+
+            set
+            {
+                if (value && !CrossPlatformHelpers.IsLinux)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+
+                this.followSymlink = value;
+            }
+        }
     }
 }

--- a/lib/TransferScheduler.cs
+++ b/lib/TransferScheduler.cs
@@ -211,6 +211,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             catch (Exception ex) when (ex is StorageException || (ex is AggregateException && ex.InnerException is StorageException))
             {
                 var storageException = ex as StorageException ?? ex.InnerException as StorageException;
+
+                if (storageException.InnerException is OperationCanceledException)
+                {
+                    throw storageException.InnerException;
+                }
+
                 throw new TransferException(TransferErrorCode.Unknown,
                     Resources.UncategorizedException,
                     storageException);

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -47,7 +47,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// the writer should do or not do validation on content md5 according to this value.
         /// </summary>
         public bool DisableContentMD5Validation { get; set; }
-
+        
         /// <summary>
         /// Gets or sets attribute for blob/azure file.
         /// </summary>

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\..\test\DMLibTest\Cases\DelimiterTest.cs" Link="Cases\DelimiterTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\LongFilePathTest.cs" Link="Cases\LongFilePathTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\MetadataTest.cs" Link="Cases\MetadataTest.cs" />
+    <Compile Include="..\..\test\DMLibTest\Cases\NonseekableStreamTest.cs" Link="Cases\NonseekableStreamTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\OverwriteTest.cs" Link="Cases\OverwriteTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\ProgressHandlerTest.cs" Link="Cases\ProgressHandlerTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\ResumeTest.cs" Link="Cases\ResumeTest.cs" />
@@ -83,6 +84,7 @@
     <Compile Include="..\..\test\DMLibTest\Generated\UnsupportedDirectionTest_Generated.cs" Link="Generated\UnsupportedDirectionTest_Generated.cs" />
     <Compile Include="..\..\test\DMLibTest\Util\DMLibTestConstants.cs" Link="Util\DMLibTestConstants.cs" />
     <Compile Include="..\..\test\DMLibTest\Util\DMLibTestHelper.cs" Link="Util\DMLibTestHelper.cs" />
+    <Compile Include="..\..\test\DMLibTest\Util\DMLibTestStream.cs" Link="Util\DMLibTestStream.cs" />
     <Compile Include="..\..\test\DMLibTest\Util\Helpers.cs" Link="Util\Helpers.cs" />
     <Compile Include="..\..\test\DMLibTest\Util\SASGenerator.cs" Link="Util\SASGenerator.cs" />
     <Compile Include="..\..\test\DMLibTest\Util\TestAccounts.cs" Link="Util\TestAccounts.cs" />

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -9,6 +9,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50;portable-net45+win8</AssetTargetFallback>
     <RuntimeFrameworkVersion>2.0</RuntimeFrameworkVersion>
+    <DebugType>portable</DebugType>
     <DefineConstants>$(DefineConstants);DOTNET5_4;DNXCORE50;EXPECT_INTERNAL_WRAPPEDSTORAGEEXCEPTION;RUNTIME_INFORMATION</DefineConstants>
   </PropertyGroup>
 

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -22,6 +22,7 @@
     <Compile Include="..\..\test\DMLibTest\Cases\CheckContentMD5Test.cs" Link="Cases\CheckContentMD5Test.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\ChunkedMemoryStreamTests.cs" Link="Cases\ChunkedMemoryStreamTests.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\DelimiterTest.cs" Link="Cases\DelimiterTest.cs" />
+    <Compile Include="..\..\test\DMLibTest\Cases\FollowSymlinkTest.cs" Link="Cases\FollowSymlinkTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\LongFilePathTest.cs" Link="Cases\LongFilePathTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\MetadataTest.cs" Link="Cases\MetadataTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\NonseekableStreamTest.cs" Link="Cases\NonseekableStreamTest.cs" />
@@ -71,6 +72,7 @@
     <Compile Include="..\..\test\DMLibTest\Generated\BVT_Generated.cs" Link="Generated\BVT_Generated.cs" />
     <Compile Include="..\..\test\DMLibTest\Generated\CheckContentMD5Test_Generated.cs" Link="Generated\CheckContentMD5Test_Generated.cs" />
     <Compile Include="..\..\test\DMLibTest\Generated\DelimiterTest_Generated.cs" Link="Generated\DelimiterTest_Generated.cs" />
+    <Compile Include="..\..\test\DMLibTest\Generated\FollowSymlinkTest_Generated.cs" Link="Generated\FollowSymlinkTest_Generated.cs" />
     <Compile Include="..\..\test\DMLibTest\Generated\LongFilePathTest_Generated.cs" Link="Generated\LongFilePathTest_Generated.cs" />
     <Compile Include="..\..\test\DMLibTest\Generated\MetadataTest_Generated.cs" Link="Generated\MetadataTest_Generated.cs" />
     <Compile Include="..\..\test\DMLibTest\Generated\OverwriteTest_Generated.cs" Link="Generated\OverwriteTest_Generated.cs" />

--- a/netcore/DMLibTest/TestClassFixtures.cs
+++ b/netcore/DMLibTest/TestClassFixtures.cs
@@ -95,6 +95,19 @@ namespace DMLibTest
         }
     }
 
+    public class FollowSymlinkTestFixture : IDisposable
+    {
+        public FollowSymlinkTestFixture()
+        {
+            FollowSymlinkTest.MyClassInitialize(null);
+        }
+
+        public void Dispose()
+        {
+            FollowSymlinkTest.MyClassCleanup();
+        }
+    }
+
     public class LongFilePathTestFixture : IDisposable
     {
         public LongFilePathTestFixture()

--- a/netcore/DMLibTest/TestClassFixtures.cs
+++ b/netcore/DMLibTest/TestClassFixtures.cs
@@ -121,6 +121,18 @@ namespace DMLibTest
         }
     }
 
+    public class NonseekableStreamTestFixture : IDisposable
+    {
+        public NonseekableStreamTestFixture()
+        {
+            NonseekableStreamTest.MyClassInitialize(null);
+        }
+        public void Dispose()
+        {
+            NonseekableStreamTest.MyClassCleanup();
+        }
+    }
+
     public class OverwriteTestFixture : IDisposable
     {
         public OverwriteTestFixture()

--- a/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft.WindowsAzure.Storage.DataMovement Class Library</Description>
-    <Version>0.6.6.0</Version>
+    <Version>0.7.0.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -25,10 +25,16 @@
 
   <ItemGroup>
     <Compile Include="..\..\lib\**\*.cs;..\..\tools\AssemblyInfo\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
-    <EmbeddedResource Include="..\..\lib\Resources.resx" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="..\..\lib\Resources.resx" Link="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0-beta2" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.6.0" />

--- a/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
@@ -6,6 +6,7 @@
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DebugType>portable</DebugType>
     <DelaySign>true</DelaySign>
     <AssemblyName>Microsoft.WindowsAzure.Storage.DataMovement</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/strongnamekeys/fake/windows.snk</AssemblyOriginatorKeyFile>

--- a/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
@@ -48,8 +48,8 @@
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.8.6.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.6.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.6.6\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.7.0\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/samples/DataMovementSamples/DataMovementSamples/packages.config
+++ b/samples/DataMovementSamples/DataMovementSamples/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="0.6.6" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="0.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.6.6" />
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.7.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
+++ b/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
@@ -60,8 +60,8 @@
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.8.6.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.6.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.6.6\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.7.0\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/samples/S3ToAzureSample/S3ToAzureSample/packages.config
+++ b/samples/S3ToAzureSample/S3ToAzureSample/packages.config
@@ -3,7 +3,7 @@
   <package id="AWSSDK.Core" version="3.1.1.0" targetFramework="net45" />
   <package id="AWSSDK.S3" version="3.1.2.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="0.6.6" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="0.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/test/DMLibTest/Cases/FollowSymlinkTest.cs
+++ b/test/DMLibTest/Cases/FollowSymlinkTest.cs
@@ -217,6 +217,9 @@ namespace DMLibTest
                 },
             };
 
+            // This case may takes very long time.
+            options.TimeoutInMs = 60 * 60 * 1000;
+
             var result = this.ExecuteTestCase(sourceDataInfo, options);
 
             // For sync copy, recalculate md5 of destination by downloading the file to local.
@@ -258,8 +261,11 @@ namespace DMLibTest
                     transferOptions.Recursive = true;
                     (transferOptions as UploadDirectoryOptions).FollowSymlink = true;
                     item.Options = transferOptions;
-                },
+                }
             };
+
+            // This case may takes very long time.
+            options.TimeoutInMs = 60 * 60 * 1000;
 
             var result = this.ExecuteTestCase(sourceDataInfo, options);
             Test.Assert(result.Exceptions.Count == 1 && result.Exceptions[0] is TransferException && result.Exceptions[0].InnerException.Message.Contains("Too many levels of symbolic links"), "Verify expected exception is thrown.");
@@ -342,8 +348,11 @@ namespace DMLibTest
                     (transferOptions as UploadDirectoryOptions).FollowSymlink = true;
                     item.Options = transferOptions;
                 },
-                DisableSourceCleaner = true
+                DisableSourceCleaner = true,
             };
+
+            // This case may takes very long time.
+            options.TimeoutInMs = 60 * 60 * 1000;
 
             var result = this.ExecuteTestCase(sourceDataInfo, options);
             foreach (var exception in result.Exceptions)

--- a/test/DMLibTest/Cases/FollowSymlinkTest.cs
+++ b/test/DMLibTest/Cases/FollowSymlinkTest.cs
@@ -346,6 +346,11 @@ namespace DMLibTest
             };
 
             var result = this.ExecuteTestCase(sourceDataInfo, options);
+            foreach (var exception in result.Exceptions)
+            {
+                Test.Info(exception.Message);
+            }
+
             Test.Assert(result.Exceptions.Count == 1 && result.Exceptions[0] is TransferException && result.Exceptions[0].InnerException.Message.Contains("Too many levels of symbolic links"), "Verify expected exception is thrown.");
 #endif
         }
@@ -358,7 +363,8 @@ namespace DMLibTest
 #if DNXCORE50
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("");
             DMLibDataInfo targetDataInfo = new DMLibDataInfo("target");
-            
+            UnicodeFileName = "TempTestName";
+
             DirNode dirNode = new DirNode($"{UnicodeFileName}{FolderSuffix}");
             dirNode.AddFileNode(new FileNode($"{UnicodeFileName}{FileSuffix}")
             {
@@ -371,7 +377,7 @@ namespace DMLibTest
             DestAdaptor.CreateIfNotExists();
 
             SourceAdaptor.GenerateData(targetDataInfo);
-            sourceDataInfo.RootNode = DirNode.SymlinkedDir($"{UnicodeFileName}{SymlinkSuffix}", $"target", targetDataInfo.RootNode);
+            sourceDataInfo.RootNode = DirNode.SymlinkedDir($"{UnicodeFileName}{SymlinkSuffix}", "target", targetDataInfo.RootNode);
             SourceAdaptor.GenerateData(sourceDataInfo);
 
             TransferItem item = new TransferItem()
@@ -383,11 +389,10 @@ namespace DMLibTest
                 DestType = DMLibTestContext.DestType,
                 IsServiceCopy = DMLibTestContext.IsAsync,
                 TransferContext = new DirectoryTransferContext(),
-                Options = new UploadDirectoryOptions()
-                {
-                    Recursive = true,                    
-                },
+                Options = DefaultTransferDirectoryOptions
             };
+
+            (item.Options as UploadDirectoryOptions).Recursive = true;
 
             var result = this.RunTransferItems(new List<TransferItem>() { item }, new TestExecutionOptions<DMLibDataInfo>());
 

--- a/test/DMLibTest/Cases/FollowSymlinkTest.cs
+++ b/test/DMLibTest/Cases/FollowSymlinkTest.cs
@@ -76,7 +76,7 @@ namespace DMLibTest
         public void FollowSymlink_Set_True()
         {
 #if DNXCORE50
-            var uploadOption = new UploadDirectoryOptions();
+           var uploadOption = new UploadDirectoryOptions();
             bool gotException = false;
 
             try
@@ -104,6 +104,11 @@ namespace DMLibTest
         public void FollowSymlink_1_SymlinkDir()
         {
 #if DNXCORE50
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                return;
+            }
+
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
 
             var dirNode = new DirNode($"{UnicodeFileName}{FolderSuffix}");
@@ -145,6 +150,10 @@ namespace DMLibTest
         public void FollowSymlink_Random_SymlinkDir_OnSameLevel()
         {
 #if DNXCORE50
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                return;
+            }
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
 
             int level = random.Next(2, 40);
@@ -197,6 +206,10 @@ namespace DMLibTest
         public void FollowSymlink_Random_Levels_SymlinkDir()
         {
 #if DNXCORE50
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                return;
+            }
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
 
             int level = random.Next(2, 40);
@@ -244,6 +257,10 @@ namespace DMLibTest
         public void FollowSymlink_Random_Levels_40_SymlinkDir()
         {
 #if DNXCORE50
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                return;
+            }
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
 
             int level = random.Next(40, 60);
@@ -281,6 +298,10 @@ namespace DMLibTest
         public void FollowSymlink_DeadLoop_1()
         {
 #if DNXCORE50
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                return;
+            }
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
             DirNode targetFolder = new DirNode($"{UnicodeFileName}{FolderSuffix}");
             targetFolder.AddFileNode(new FileNode($"{UnicodeFileName}{FileSuffix}")
@@ -319,6 +340,10 @@ namespace DMLibTest
         public void FollowSymlink_DeadLoop_2()
         {
 #if DNXCORE50
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                return;
+            }
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
             DMLibDataInfo targetDataInfo = new DMLibDataInfo("targetC");
 
@@ -370,6 +395,10 @@ namespace DMLibTest
         public void Upload_Symlinked_RootDir()
         {
 #if DNXCORE50
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                return;
+            }
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("");
             DMLibDataInfo targetDataInfo = new DMLibDataInfo("target");
             UnicodeFileName = "TempTestName";

--- a/test/DMLibTest/Cases/FollowSymlinkTest.cs
+++ b/test/DMLibTest/Cases/FollowSymlinkTest.cs
@@ -1,0 +1,369 @@
+﻿
+
+namespace DMLibTest
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using DMLibTestCodeGen;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.WindowsAzure.Storage.DataMovement;
+    using MS.Test.Common.MsTestLib;
+
+    [MultiDirectionTestClass]
+    public class FollowSymlinkTest : DMLibTestBase
+#if DNXCORE50
+        , IDisposable
+#endif
+    {
+
+        private static string UnicodeFileName = "Prefix"; //FileOp.NextString(random, random.Next(6, 10));
+        private const string FolderSuffix = "_Folder";
+        private const string FileSuffix = "_File";
+        private const string SymlinkSuffix = "_Link";
+
+        #region Initialization and cleanup methods
+
+#if DNXCORE50
+        public FollowSymlinkTest()
+        {
+            MyTestInitialize();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            MyTestCleanup();
+        }
+#endif
+
+        [ClassInitialize()]
+        public static void MyClassInitialize(TestContext testContext)
+        {
+            Test.Info("Class Initialize: FollowSymlinkTest");
+            DMLibTestBase.BaseClassInitialize(testContext);
+            
+            Test.Info("Use file name {0} in BVT.", UnicodeFileName);
+        }
+
+        [ClassCleanup()]
+        public static void MyClassCleanup()
+        {
+            DMLibTestBase.BaseClassCleanup();
+        }
+
+        [TestInitialize()]
+        public void MyTestInitialize()
+        {
+            base.BaseTestInitialize();
+        }
+
+        [TestCleanup()]
+        public void MyTestCleanup()
+        {
+            base.BaseTestCleanup();
+        }
+
+        #endregion
+
+        [TestCategory(Tag.Function)]
+        [DMLibTestMethodSet(DMLibTestMethodSet.DirLocalSource)]
+        public void FollowSymlink_Set_True()
+        {
+#if DNXCORE50
+            var uploadOption = new UploadDirectoryOptions();
+            bool gotException = false;
+
+            try
+            {
+                uploadOption.FollowSymlink = true;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                gotException = true;
+            }
+
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                Test.Assert(gotException, "Should throw not supported exception on non-Linux platform.");
+            }
+            else
+            {
+                Test.Assert(uploadOption.FollowSymlink == true, "Follow symlink is set correctly");
+            }
+#endif
+        }
+
+        [TestCategory(Tag.Function)]
+        [DMLibTestMethodSet(DMLibTestMethodSet.DirLocalSource)]
+        public void FollowSymlink_1_SymlinkDir()
+        {
+#if DNXCORE50
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
+
+            var dirNode = new DirNode($"{UnicodeFileName}{FolderSuffix}");
+            dirNode.AddFileNode(new FileNode($"{UnicodeFileName}{FileSuffix}")
+            {
+                SizeInByte = 1024
+            });
+
+            sourceDataInfo.RootNode.AddDirNode(dirNode);
+            sourceDataInfo.RootNode.AddDirNode(DirNode.SymlinkedDir($"{UnicodeFileName}{SymlinkSuffix}", dirNode.Name, dirNode));
+
+            var options = new TestExecutionOptions<DMLibDataInfo>()
+            {
+                IsDirectoryTransfer = true,
+                TransferItemModifier = (notUsed, item) =>
+                {
+                    dynamic transferOptions = DefaultTransferDirectoryOptions;
+                    transferOptions.Recursive = true;
+                    (transferOptions as UploadDirectoryOptions).FollowSymlink = true;
+                    item.Options = transferOptions;
+                },
+            };
+
+            var result = this.ExecuteTestCase(sourceDataInfo, options);
+
+            // For sync copy, recalculate md5 of destination by downloading the file to local.
+            if (IsCloudService(DMLibTestContext.DestType) && !DMLibTestContext.IsAsync)
+            {
+                DMLibDataHelper.SetCalculatedFileMD5(result.DataInfo, DestAdaptor);
+            }
+
+            Test.Assert(result.Exceptions.Count == 0, "Verify no exception is thrown.");
+            Test.Assert(DMLibDataHelper.Equals(sourceDataInfo, result.DataInfo), "Verify transfer result.");
+#endif
+        }
+
+        [TestCategory(Tag.Function)]
+        [DMLibTestMethodSet(DMLibTestMethodSet.DirLocalSource)]
+        public void FollowSymlink_Random_SymlinkDir_OnSameLevel()
+        {
+#if DNXCORE50
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
+
+            int level = random.Next(2, 40);
+
+            for (int i = 0; i < level; ++i)
+            {
+                var dirNode = new DirNode($"{UnicodeFileName}{FolderSuffix}_{i}");
+                dirNode.AddFileNode(new FileNode($"{UnicodeFileName}{FileSuffix}")
+                {
+                    SizeInByte = 1024
+                });
+
+                sourceDataInfo.RootNode.AddDirNode(dirNode);
+                sourceDataInfo.RootNode.AddDirNode(DirNode.SymlinkedDir($"{UnicodeFileName}{SymlinkSuffix}_{i}", dirNode.Name, dirNode));
+            }
+
+            var options = new TestExecutionOptions<DMLibDataInfo>()
+            {
+                IsDirectoryTransfer = true,
+                TransferItemModifier = (notUsed, item) =>
+                {
+                    dynamic transferOptions = DefaultTransferDirectoryOptions;
+                    transferOptions.Recursive = true;
+                    (transferOptions as UploadDirectoryOptions).FollowSymlink = true;
+                    item.Options = transferOptions;
+                },
+            };
+
+            var result = this.ExecuteTestCase(sourceDataInfo, options);
+
+            // For sync copy, recalculate md5 of destination by downloading the file to local.
+            if (IsCloudService(DMLibTestContext.DestType) && !DMLibTestContext.IsAsync)
+            {
+                DMLibDataHelper.SetCalculatedFileMD5(result.DataInfo, DestAdaptor);
+            }
+
+            Test.Assert(result.Exceptions.Count == 0, "Verify no exception is thrown.");
+            Test.Assert(DMLibDataHelper.Equals(sourceDataInfo, result.DataInfo), "Verify transfer result.");
+#endif
+        }
+
+        /// n < 40
+        /// Symlink_(n-1) -> Folder_n
+        ///           -  File_(n-2)
+        ///           -  Symlink_(n-2) -> Folder_(n-1)... ... Symlink_0 -> Folder_1
+        ///                                                   - File_0
+        ///
+        [TestCategory(Tag.Function)]
+        [DMLibTestMethodSet(DMLibTestMethodSet.DirLocalSource)]
+        public void FollowSymlink_Random_Levels_SymlinkDir()
+        {
+#if DNXCORE50
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
+
+            int level = random.Next(2, 40);
+
+            Test.Info($"Testing {level} levels of symlinked dirs");
+
+            BuildDeepSymlinkDir(sourceDataInfo.RootNode, sourceDataInfo.RootNode, level);
+
+            var options = new TestExecutionOptions<DMLibDataInfo>()
+            {
+                IsDirectoryTransfer = true,
+                TransferItemModifier = (notUsed, item) =>
+                {
+                    dynamic transferOptions = DefaultTransferDirectoryOptions;
+                    transferOptions.Recursive = true;
+                    (transferOptions as UploadDirectoryOptions).FollowSymlink = true;
+                    item.Options = transferOptions;
+                },
+            };
+
+            var result = this.ExecuteTestCase(sourceDataInfo, options);
+
+            // For sync copy, recalculate md5 of destination by downloading the file to local.
+            if (IsCloudService(DMLibTestContext.DestType) && !DMLibTestContext.IsAsync)
+            {
+                DMLibDataHelper.SetCalculatedFileMD5(result.DataInfo, DestAdaptor);
+            }
+
+            Test.Assert(result.Exceptions.Count == 0, "Verify no exception is thrown.");
+            Test.Assert(DMLibDataHelper.Equals(sourceDataInfo, result.DataInfo), "Verify transfer result.");
+#endif
+        }
+
+        /// n >= 40
+        /// Symlink_(n-1) -> Folder_n
+        ///           -  File_(n-2)
+        ///           -  Symlink_(n-2) -> Folder_(n-1)... ... Symlink_0 -> Folder_1
+        ///                                                   - File_0
+        /// 
+        [TestCategory(Tag.Function)]
+        [DMLibTestMethodSet(DMLibTestMethodSet.DirLocalSource)]
+        public void FollowSymlink_Random_Levels_40_SymlinkDir()
+        {
+#if DNXCORE50
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
+
+            int level = random.Next(40, 60);
+
+            Test.Info($"Testing {level} levels of symlinked dirs");
+
+            BuildDeepSymlinkDir(sourceDataInfo.RootNode, sourceDataInfo.RootNode, level);
+
+            var options = new TestExecutionOptions<DMLibDataInfo>()
+            {
+                IsDirectoryTransfer = true,
+                TransferItemModifier = (notUsed, item) =>
+                {
+                    dynamic transferOptions = DefaultTransferDirectoryOptions;
+                    transferOptions.Recursive = true;
+                    (transferOptions as UploadDirectoryOptions).FollowSymlink = true;
+                    item.Options = transferOptions;
+                },
+            };
+
+            var result = this.ExecuteTestCase(sourceDataInfo, options);
+            Test.Assert(result.Exceptions.Count == 1 && result.Exceptions[0] is TransferException && result.Exceptions[0].InnerException.Message.Contains("Too many levels of symbolic links"), "Verify expected exception is thrown.");
+#endif
+        }
+        
+        /// 
+        /// targetDir
+        ///      - symlink -> ../targetDir
+        ///      - file
+        [TestCategory(Tag.Function)]
+        [DMLibTestMethodSet(DMLibTestMethodSet.DirLocalSource)]
+        public void FollowSymlink_DeadLoop_1()
+        {
+#if DNXCORE50
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
+            DirNode targetFolder = new DirNode($"{UnicodeFileName}{FolderSuffix}");
+            targetFolder.AddFileNode(new FileNode($"{UnicodeFileName}{FileSuffix}")
+            {
+                SizeInByte = 1024
+            });
+
+            targetFolder.AddDirNode(DirNode.SymlinkedDir($"{UnicodeFileName}{SymlinkSuffix}", Path.Combine("..", $"{UnicodeFileName}{FolderSuffix}"), targetFolder));
+
+            sourceDataInfo.RootNode.AddDirNode(targetFolder);
+
+            var options = new TestExecutionOptions<DMLibDataInfo>()
+            {
+                IsDirectoryTransfer = true,
+                TransferItemModifier = (notUsed, item) =>
+                {
+                    dynamic transferOptions = DefaultTransferDirectoryOptions;
+                    transferOptions.Recursive = true;
+                    (transferOptions as UploadDirectoryOptions).FollowSymlink = true;
+                    item.Options = transferOptions;
+                }
+            };
+
+            var result = this.ExecuteTestCase(sourceDataInfo, options);
+            Test.Assert(result.Exceptions.Count == 1 && result.Exceptions[0] is TransferException && result.Exceptions[0].Message.Contains("Potential dead loop in directory structure due to symbolic link"), "Verify expected exception is thrown.");
+#endif
+        }
+        
+        /// Root dir struct        | target dir struct
+        /// root -                 | C
+        ///      - symlink-> B     |  - B
+        ///                        |  - symlink -> ../../C
+        ///                        |  
+        [TestCategory(Tag.Function)]
+        [DMLibTestMethodSet(DMLibTestMethodSet.DirLocalSource)]
+        public void FollowSymlink_DeadLoop_2()
+        {
+#if DNXCORE50
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
+            DMLibDataInfo targetDataInfo = new DMLibDataInfo("targetC");
+
+            DirNode dirNodeC = new DirNode("folder_C");
+            DirNode dirNodeB = new DirNode("folder_B");
+            dirNodeB.AddFileNode(new FileNode("File_B")
+            {
+                SizeInByte = 1024
+            });
+
+            dirNodeC.AddDirNode(dirNodeB);
+            dirNodeB.AddDirNode(DirNode.SymlinkedDir("symlinkToC", "../../folder_C", dirNodeC));
+            targetDataInfo.RootNode.AddDirNode(dirNodeC);
+
+            SourceAdaptor.CreateIfNotExists();
+            SourceAdaptor.GenerateData(targetDataInfo);
+
+            sourceDataInfo.RootNode.AddDirNode(DirNode.SymlinkedDir("symlinkToB", "../targetC/folder_C/folder_B", dirNodeB));
+
+            var options = new TestExecutionOptions<DMLibDataInfo>()
+            {
+                IsDirectoryTransfer = true,
+                TransferItemModifier = (notUsed, item) =>
+                {
+                    dynamic transferOptions = DefaultTransferDirectoryOptions;
+                    transferOptions.Recursive = true;
+                    (transferOptions as UploadDirectoryOptions).FollowSymlink = true;
+                    item.Options = transferOptions;
+                },
+                DisableSourceCleaner = true
+            };
+
+            var result = this.ExecuteTestCase(sourceDataInfo, options);
+            Test.Assert(result.Exceptions.Count == 1 && result.Exceptions[0] is TransferException && result.Exceptions[0].InnerException.Message.Contains("Too many levels of symbolic links"), "Verify expected exception is thrown.");
+#endif
+        }
+
+        private void BuildDeepSymlinkDir(DirNode rootDir, DirNode parent, int level)
+        {
+            DirNode subDir = new DirNode($"{UnicodeFileName}{FolderSuffix}_{level}");
+
+            if (--level > 0)
+            {
+                BuildDeepSymlinkDir(rootDir, subDir, level);
+            }
+
+            subDir.AddFileNode(new FileNode($"{UnicodeFileName}{FileSuffix}")
+            {
+                SizeInByte = 1024
+            });
+            rootDir.AddDirNode(subDir);
+            parent.AddDirNode(DirNode.SymlinkedDir($"{UnicodeFileName}{SymlinkSuffix}_{level}", Path.Combine(Object.ReferenceEquals(rootDir, parent) ? "" : "..", subDir.Name), subDir));
+        }
+    }
+}

--- a/test/DMLibTest/Cases/NonseekableStreamTest.cs
+++ b/test/DMLibTest/Cases/NonseekableStreamTest.cs
@@ -1,0 +1,314 @@
+﻿
+namespace DMLibTest.Cases
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using DMLibTest.Util;
+    using DMLibTestCodeGen;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.WindowsAzure.Storage.Blob;
+    using Microsoft.WindowsAzure.Storage.File;
+    using MS.Test.Common.MsTestLib;
+#if DNXCORE50
+    using Xunit;
+
+    [Collection(Collections.Global)]
+    public class NonseekableStreamTest : DMLibTestBase, IClassFixture<NonseekableStreamTestFixture>, IDisposable
+    {
+        public NonseekableStreamTest()
+        {
+            MyTestInitialize();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            MyTestCleanup();
+        }
+#else
+    [TestClass]
+    public class NonseekableStreamTest : DMLibTestBase
+    {
+#endif
+        private static readonly long[] VariedFileSize = new long[] { 0, 1, 4194304};
+#region Additional test attributes
+
+        [ClassInitialize()]
+        public static void MyClassInitialize(TestContext testContext)
+        {
+            Test.Info("Class Initialize: NonseekableStreamTest");
+            DMLibTestBase.BaseClassInitialize(testContext);
+            DMLibTestBase.CleanupSource = false;            
+        }
+
+        [ClassCleanup()]
+        public static void MyClassCleanup()
+        {
+            DMLibTestBase.BaseClassCleanup();
+        }
+
+        [TestInitialize()]
+        public void MyTestInitialize()
+        {
+            base.BaseTestInitialize();
+        }
+
+        [TestCleanup()]
+        public void MyTestCleanup()
+        {
+            base.BaseTestCleanup();
+        }
+#endregion
+
+        [TestMethod]
+        [TestCategory(Tag.Function)]
+#if DNXCORE50
+        [TestStartEnd()]
+#endif
+        public void UploadVariedSizeObject_Nonseekable_NonfixedSized_Positive()
+        {
+            DMLibDataType[] destTypes = new DMLibDataType[] { DMLibDataType.BlockBlob, DMLibDataType.AppendBlob };
+            foreach (var destType in destTypes)
+            {
+                UploadFromStreamTest(destType, VariedFileSize, null, false, false);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(Tag.Function)]
+#if DNXCORE50
+        [TestStartEnd()]
+#endif
+        public void UploadLargeObject_Nonseekable_NonfixedSized_Positive()
+        {
+            DMLibDataType[] destTypes = new DMLibDataType[] { DMLibDataType.BlockBlob, DMLibDataType.AppendBlob };
+            foreach (var destType in destTypes)
+            {
+                int length4MB = 4 * 1024 * 1024;
+                int blockSize = (random.Next(length4MB, 100 * 1024 * 1024) / length4MB) * length4MB;
+
+                UploadFromStreamTest(destType, 
+                    random.Next(10, 200) * 1024 * 1024,
+                    blockSize, 
+                    false, 
+                    false);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(Tag.Function)]
+#if DNXCORE50
+        [TestStartEnd()]
+#endif
+        public void UploadVariedSizeObject_Nonseekable_Positive()
+        {
+            DMLibDataType[] destTypes = new DMLibDataType[] 
+            {
+                DMLibDataType.BlockBlob,
+                DMLibDataType.AppendBlob,
+                DMLibDataType.PageBlob,
+                DMLibDataType.CloudFile
+            };
+
+            foreach (var destType in destTypes)
+            {
+                if (DMLibDataType.PageBlob != destType)
+                {
+                    UploadFromStreamTest(destType, VariedFileSize, null, false, true);
+                }
+                else
+                {
+                    List<long> variedFileSize = new List<long>();
+                    foreach (var fileSize in VariedFileSize)
+                    {
+                        variedFileSize.Add((int)Math.Ceiling(((double)fileSize) / 512) * 512);
+                    }
+
+                    UploadFromStreamTest(destType, variedFileSize.ToArray(), null, false, true);
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(Tag.Function)]
+#if DNXCORE50
+        [TestStartEnd()]
+#endif
+        public void UploadLargeObject_Nonseekable_Positive()
+        {
+            DMLibDataType[] destTypes = new DMLibDataType[]
+            {
+                DMLibDataType.BlockBlob,
+                DMLibDataType.AppendBlob,
+                DMLibDataType.PageBlob,
+                DMLibDataType.CloudFile
+            };
+
+            foreach (var destType in destTypes)
+            {
+                int length4MB = 4 * 1024 * 1024;
+                int blockSize = (random.Next(length4MB, 100 * 1024 * 1024) / length4MB) * length4MB;
+
+                UploadFromStreamTest(destType,
+                    random.Next(10, 200) * 1024 * 1024,
+                    blockSize, 
+                    false, 
+                    true);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(Tag.Function)]
+#if DNXCORE50
+        [TestStartEnd()]
+#endif
+        public void UploadLargeObject_Nonseekable_NonfixedSize_Nagitive()
+        {
+            DMLibDataType[] destTypes = new DMLibDataType[]
+            {
+                DMLibDataType.PageBlob,
+                DMLibDataType.CloudFile
+            };
+
+            foreach (var destType in destTypes)
+            {
+                int length4MB = 4 * 1024 * 1024;
+                int blockSize = (random.Next(length4MB, 100 * 1024 * 1024) / length4MB) * length4MB;
+
+                UploadFromStreamTest(destType,
+                    random.Next(10, 200) * 1024 * 1024,
+                    blockSize,
+                    false,
+                    false);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(Tag.Function)]
+#if DNXCORE50
+        [TestStartEnd()]
+#endif
+        public void UploadLargeObject_Nonseekable_PageBlob_Nagitive()
+        {
+            DataAdaptor<DMLibDataInfo> sourceAdaptor = GetSourceAdaptor(DMLibDataType.Stream);
+            DataAdaptor<DMLibDataInfo> destAdaptor = GetDestAdaptor(DMLibDataType.PageBlob);
+
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);
+
+            sourceDataInfo.RootNode.AddFileNode(new FileNode($"{FileName}_{1}B")
+            {
+                SizeInByte = 1,
+            });
+
+            sourceAdaptor.GenerateData(sourceDataInfo);
+            destAdaptor.CreateIfNotExists();
+
+            List<TransferItem> uploadItems = new List<TransferItem>();
+
+            string fileName = $"{FileName}_{1}B";
+            FileNode fileNode = sourceDataInfo.RootNode.GetFileNode(fileName);
+
+            uploadItems.Add(new TransferItem()
+            {
+                SourceObject = new DMLibTestStream(sourceAdaptor.GetTransferObject(string.Empty, fileNode) as FileStream, false, true),
+                DestObject = destAdaptor.GetTransferObject(string.Empty, fileNode),
+                SourceType = DMLibDataType.Stream,
+                DestType = DMLibDataType.PageBlob,
+                IsServiceCopy = false
+            });
+
+            // Execution
+            var result = this.RunTransferItems(
+                uploadItems,
+                new TestExecutionOptions<DMLibDataInfo>()
+                {
+                    DisableDestinationFetch = true
+                });
+
+            Test.Assert(result.Exceptions.Count == 1 && result.Exceptions[0].Message.Contains("must be a multiple of 512 bytes."), "Verify error is expected.");
+
+            sourceAdaptor.Cleanup();
+            destAdaptor.Cleanup();
+        }
+
+        private void UploadFromStreamTest(DMLibDataType destType, long sourceLength, int? blockSize, bool seekable, bool fixedSized)
+        {
+            this.UploadFromStreamTest(destType, new long[] { sourceLength }, blockSize, seekable, fixedSized);
+        }
+
+        private void UploadFromStreamTest(DMLibDataType destType, long[] variedSourceLength, int? blockSize, bool seekable, bool fixedSized)
+        {
+            DataAdaptor<DMLibDataInfo> sourceAdaptor = GetSourceAdaptor(DMLibDataType.Stream);
+            DataAdaptor<DMLibDataInfo> destAdaptor = GetDestAdaptor(destType);
+
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);
+
+            foreach (long fileSizeInByte in variedSourceLength)
+            {
+                sourceDataInfo.RootNode.AddFileNode(new FileNode($"{FileName}_{fileSizeInByte}")
+                {
+                    SizeInByte = fileSizeInByte,
+                });
+            }
+
+            sourceAdaptor.GenerateData(sourceDataInfo);
+            destAdaptor.CreateIfNotExists();
+
+            List<TransferItem> uploadItems = new List<TransferItem>();
+
+            foreach (long fileSizeInByte in variedSourceLength)
+            {
+                string fileName = $"{FileName}_{fileSizeInByte}";
+                FileNode fileNode = sourceDataInfo.RootNode.GetFileNode(fileName);
+
+                uploadItems.Add(new TransferItem()
+                {
+                    SourceObject = new DMLibTestStream(sourceAdaptor.GetTransferObject(string.Empty, fileNode) as FileStream, seekable, fixedSized),
+                    DestObject = destAdaptor.GetTransferObject(string.Empty, fileNode),
+                    SourceType = DMLibDataType.Stream,
+                    DestType = destType,
+                    IsServiceCopy = false
+                });
+            }
+
+            // Execution
+            var result = this.RunTransferItems(
+                uploadItems, 
+                new TestExecutionOptions<DMLibDataInfo>()
+                {
+                    DisableDestinationFetch = true,
+                    BlockSize = blockSize.HasValue ? blockSize.Value : 4 * 1024 * 1024
+                });
+
+            if (!fixedSized && (destType == DMLibDataType.PageBlob || destType == DMLibDataType.CloudFile))
+            {
+                Test.Assert(result.Exceptions.Count == 1 && result.Exceptions[0].Message.Contains("Source must be fixed size"), "Verify error is expected.");
+
+            }
+            else
+            {
+                // Verify all files are transfered successfully
+                Test.Assert(result.Exceptions.Count == 0, "Verify no exception occurs.");
+
+                DMLibDataInfo destDataInfo = destAdaptor.GetTransferDataInfo(string.Empty);
+
+                foreach (FileNode destFileNode in destDataInfo.EnumerateFileNodes())
+                {
+                    FileNode sourceFileNode = sourceDataInfo.RootNode.GetFileNode(destFileNode.Name);
+                    Test.Assert(DMLibDataHelper.Equals(sourceFileNode, destFileNode), "Verify transfer result.");
+                }
+            }
+
+            sourceAdaptor.Cleanup();
+            destAdaptor.Cleanup();
+        }
+    }
+}

--- a/test/DMLibTest/Cases/ResumeTest.cs
+++ b/test/DMLibTest/Cases/ResumeTest.cs
@@ -232,11 +232,11 @@ namespace DMLibTest
 
                 result = this.RunTransferItems(new List<TransferItem>() { resumeItem }, new TestExecutionOptions<DMLibDataInfo>());
 
-                if (DMLibTestContext.SourceType == DMLibDataType.Stream && DMLibTestContext.DestType != DMLibDataType.BlockBlob)
+                if (DMLibTestContext.SourceType == DMLibDataType.Stream || DMLibTestContext.DestType == DMLibDataType.Stream)
                 {
-                    Test.Assert(result.Exceptions.Count == 1, "Verify transfer is skipped when source is stream.");
+                    Test.Assert(result.Exceptions.Count == 1, "Verify error reported when source/destination is stream.");
                     exception = result.Exceptions[0];
-                    VerificationHelper.VerifyTransferException(result.Exceptions[0], TransferErrorCode.NotOverwriteExistingDestination, "Skiped file");
+                    VerificationHelper.VerifyExceptionErrorMessage(result.Exceptions[0], "Resuming transfer from or to a stream is not supported");
                 }
                 else
                 {
@@ -262,11 +262,11 @@ namespace DMLibTest
 
                     result = this.RunTransferItems(new List<TransferItem>() { resumeItem }, new TestExecutionOptions<DMLibDataInfo>());
 
-                    if (DMLibTestContext.SourceType == DMLibDataType.Stream)
+                    if (DMLibTestContext.SourceType == DMLibDataType.Stream || DMLibTestContext.DestType == DMLibDataType.Stream)
                     {
-                        Test.Assert(result.Exceptions.Count == 1, "Verify transfer is skipped when source is stream.");
+                        Test.Assert(result.Exceptions.Count == 1, "Verify error reported when source/destination is stream.");
                         exception = result.Exceptions[0];
-                        VerificationHelper.VerifyTransferException(result.Exceptions[0], TransferErrorCode.NotOverwriteExistingDestination, "Skiped file");
+                        VerificationHelper.VerifyExceptionErrorMessage(result.Exceptions[0], "Resuming transfer from or to a stream is not supported");
                     }
                     else if (DMLibTestContext.DestType == DMLibDataType.AppendBlob && !DMLibTestContext.IsAsync)
                     {

--- a/test/DMLibTest/DMLibTest.csproj
+++ b/test/DMLibTest/DMLibTest.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Cases\DelimiterTest.cs" />
     <Compile Include="Cases\LongFilePathTest.cs" />
     <Compile Include="Cases\MetadataTest.cs" />
+    <Compile Include="Cases\NonseekableStreamTest.cs" />
     <Compile Include="Cases\OverwriteTest.cs" />
     <Compile Include="Cases\ProgressHandlerTest.cs" />
     <Compile Include="Cases\ResumeTest.cs" />
@@ -169,10 +170,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Util\DMLibTestHelper.cs" />
     <Compile Include="Util\DMLibTestConstants.cs" />
+    <Compile Include="Util\DMLibTestStream.cs" />
     <Compile Include="Util\Helpers.cs" />
     <Compile Include="Util\SASGenerator.cs" />
     <Compile Include="Util\TestAccounts.cs" />
-    <Compile Include="@(GeneratedSourceFile)" Condition=" '$(Mode)' == 'Full' " />
+	<Compile Include="@(GeneratedSourceFile)" Condition=" '$(Mode)' == 'Full' " />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\lib\DataMovement.csproj">

--- a/test/DMLibTest/DMLibTest.csproj
+++ b/test/DMLibTest/DMLibTest.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Cases\BVT.cs" />
     <Compile Include="Cases\CheckContentMD5Test.cs" />
     <Compile Include="Cases\DelimiterTest.cs" />
+    <Compile Include="Cases\FollowSymlinkTest.cs" />
     <Compile Include="Cases\LongFilePathTest.cs" />
     <Compile Include="Cases\MetadataTest.cs" />
     <Compile Include="Cases\NonseekableStreamTest.cs" />

--- a/test/DMLibTest/Framework/AssemblyInitCleanup.cs
+++ b/test/DMLibTest/Framework/AssemblyInitCleanup.cs
@@ -10,6 +10,7 @@ namespace DMLibTest
     using MS.Test.Common.MsTestLib;
 
 #if DNXCORE50
+    [TestClass]
     public class AssemblyInitCleanup : IDisposable
     {
         public AssemblyInitCleanup()

--- a/test/DMLibTest/Framework/AssemblyInitCleanup.cs
+++ b/test/DMLibTest/Framework/AssemblyInitCleanup.cs
@@ -10,7 +10,6 @@ namespace DMLibTest
     using MS.Test.Common.MsTestLib;
 
 #if DNXCORE50
-    [TestClass]
     public class AssemblyInitCleanup : IDisposable
     {
         public AssemblyInitCleanup()

--- a/test/DMLibTest/Framework/DMLibTestBase.cs
+++ b/test/DMLibTest/Framework/DMLibTestBase.cs
@@ -235,7 +235,10 @@ namespace DMLibTest
 
                 try
                 {
-                    Task.WaitAll(allTasks.Values.ToArray(), options.TimeoutInMs);
+                    if (!Task.WaitAll(allTasks.Values.ToArray(), options.TimeoutInMs))
+                    {
+                        Test.Error("Running transfer items timed out");
+                    }
                 }
                 catch (Exception e)
                 {

--- a/test/DMLibTest/Framework/LocalDataAdaptor.cs
+++ b/test/DMLibTest/Framework/LocalDataAdaptor.cs
@@ -10,6 +10,8 @@ namespace DMLibTest
     using System.Collections.Generic;
     using System.IO;
     using DMLibTest.Framework;
+    using MS.Test.Common.MsTestLib;
+    using System.Threading;
 
     internal class LocalDataAdaptor : LocalDataAdaptorBase<DMLibDataInfo>
     {
@@ -100,16 +102,37 @@ namespace DMLibTest
         private void GenerateDir(DirNode dirNode, string parentPath)
         {
             string dirPath = Path.Combine(parentPath, dirNode.Name);
+                     
             DMLibDataHelper.CreateLocalDirIfNotExists(dirPath);
-
-            foreach (var subDir in dirNode.DirNodes)
-            {
-                GenerateDir(subDir, dirPath);
-            }
 
             foreach (var file in dirNode.FileNodes)
             {
                 GenerateFile(file, dirPath);
+            }
+
+            foreach (var subDir in dirNode.NormalDirNodes)
+            {
+                GenerateDir(subDir, dirPath);
+            }
+
+            foreach (var subDir in dirNode.SymlinkedDirNodes)
+            {
+                CreateSymlink(Path.Combine(dirPath, subDir.Name), subDir.Content);
+
+                Test.Info("Building symlinked dir info of {0}", Path.Combine(dirPath, subDir.Name));
+                subDir.BuildSymlinkedDirNode();
+            }
+        }
+        
+        private static void CreateSymlink(string path, string target)
+        {
+            if (CrossPlatformHelpers.IsLinux)
+            {
+                TestHelper.RunCmd("ln", $@"-s {target} {path}");
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
             }
         }
 
@@ -166,7 +189,27 @@ namespace DMLibTest
 #endif
         }
 
-        private void BuildDirNode(DirectoryInfo dirInfo, DirNode parent)
+        private void BuildSymlinkedDirNode(DirNode parent, string parentPath)
+        {
+            if (!CrossPlatformHelpers.IsLinux)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            foreach (FileNode fileNode in parent.FileNodes)
+            {
+                Test.Info("Building file info of {0}", Path.Combine(parentPath, fileNode.Name));
+                FileInfo fileInfo = new FileInfo(Path.Combine(parentPath, fileNode.Name));
+                this.BuildFileNode(fileInfo, fileNode);
+            }
+
+            foreach (DirNode dirNode in parent.DirNodes)
+            {
+                BuildSymlinkedDirNode(dirNode, Path.Combine(parentPath, dirNode.Name));
+            }
+        }
+
+    private void BuildDirNode(DirectoryInfo dirInfo, DirNode parent)
         {
             foreach (FileInfo fileInfo in dirInfo.GetFiles())
             {

--- a/test/DMLibTest/Framework/LocalDataAdaptor.cs
+++ b/test/DMLibTest/Framework/LocalDataAdaptor.cs
@@ -102,7 +102,16 @@ namespace DMLibTest
         private void GenerateDir(DirNode dirNode, string parentPath)
         {
             string dirPath = Path.Combine(parentPath, dirNode.Name);
-                     
+
+            if (!string.IsNullOrEmpty(dirNode.Content))
+            {
+                CreateSymlink(dirPath, dirNode.Content);
+
+                Test.Info("Building symlinked dir info of {0}", dirPath);
+                dirNode.BuildSymlinkedDirNode();
+                return;
+            }
+            
             DMLibDataHelper.CreateLocalDirIfNotExists(dirPath);
 
             foreach (var file in dirNode.FileNodes)
@@ -132,7 +141,7 @@ namespace DMLibTest
             }
             else
             {
-                throw new PlatformNotSupportedException();
+                //throw new PlatformNotSupportedException();
             }
         }
 

--- a/test/DMLibTest/Framework/MultiDirectionTestBase.cs
+++ b/test/DMLibTest/Framework/MultiDirectionTestBase.cs
@@ -110,8 +110,8 @@ namespace DMLibTest
         public static void BaseClassCleanup()
         {
             Test.Info("ClassCleanup");
-            DeleteAllLocations(sourceAdaptors);
-            DeleteAllLocations(destAdaptors);
+            //DeleteAllLocations(sourceAdaptors);
+            //DeleteAllLocations(destAdaptors);
             Test.Info("ClassCleanup done.");
         }
 
@@ -154,9 +154,9 @@ namespace DMLibTest
 
             try
             {
-                this.CleanupData();
-                MultiDirectionTestBase<TDataInfo, TDataType>.SourceAdaptor.Reset();
-                MultiDirectionTestBase<TDataInfo, TDataType>.DestAdaptor.Reset();
+                //this.CleanupData();
+                //MultiDirectionTestBase<TDataInfo, TDataType>.SourceAdaptor.Reset();
+                //MultiDirectionTestBase<TDataInfo, TDataType>.DestAdaptor.Reset();
             }
             catch
             {
@@ -166,9 +166,9 @@ namespace DMLibTest
 
         public virtual void CleanupData()
         {
-            this.CleanupData(
-                MultiDirectionTestBase<TDataInfo, TDataType>.CleanupSource,
-                MultiDirectionTestBase<TDataInfo, TDataType>.CleanupDestination);
+            //this.CleanupData(
+            //    MultiDirectionTestBase<TDataInfo, TDataType>.CleanupSource,
+            //    MultiDirectionTestBase<TDataInfo, TDataType>.CleanupDestination);
         }
 
         protected void CleanupData(bool cleanupSource, bool cleanupDestination)

--- a/test/DMLibTest/Framework/MultiDirectionTestBase.cs
+++ b/test/DMLibTest/Framework/MultiDirectionTestBase.cs
@@ -154,9 +154,9 @@ namespace DMLibTest
 
             try
             {
-                //this.CleanupData();
-                //MultiDirectionTestBase<TDataInfo, TDataType>.SourceAdaptor.Reset();
-                //MultiDirectionTestBase<TDataInfo, TDataType>.DestAdaptor.Reset();
+                this.CleanupData();
+                MultiDirectionTestBase<TDataInfo, TDataType>.SourceAdaptor.Reset();
+                MultiDirectionTestBase<TDataInfo, TDataType>.DestAdaptor.Reset();
             }
             catch
             {
@@ -166,9 +166,9 @@ namespace DMLibTest
 
         public virtual void CleanupData()
         {
-            //this.CleanupData(
-            //    MultiDirectionTestBase<TDataInfo, TDataType>.CleanupSource,
-            //    MultiDirectionTestBase<TDataInfo, TDataType>.CleanupDestination);
+            this.CleanupData(
+                MultiDirectionTestBase<TDataInfo, TDataType>.CleanupSource,
+                MultiDirectionTestBase<TDataInfo, TDataType>.CleanupDestination);
         }
 
         protected void CleanupData(bool cleanupSource, bool cleanupDestination)

--- a/test/DMLibTest/Util/DMLibTestStream.cs
+++ b/test/DMLibTest/Util/DMLibTestStream.cs
@@ -30,7 +30,7 @@ namespace DMLibTest.Util
                     return this.internalStream.Position;
                 }
 
-                throw new InvalidOperationException();
+                throw new NotSupportedException();
             }
 
             set
@@ -40,7 +40,7 @@ namespace DMLibTest.Util
                     this.internalStream.Position = value;
                 }
 
-                throw new InvalidOperationException();
+                throw new NotSupportedException();
             }
         }
 
@@ -53,7 +53,7 @@ namespace DMLibTest.Util
                     return this.internalStream.Length;
                 }
 
-                throw new InvalidOperationException();
+                throw new NotSupportedException();
             }
         }
 
@@ -69,7 +69,7 @@ namespace DMLibTest.Util
                 return this.internalStream.Seek(offset, origin);
             }
 
-            throw new InvalidOperationException();
+            throw new NotSupportedException();
         }
 
         public override void SetLength(long value)

--- a/test/DMLibTest/Util/DMLibTestStream.cs
+++ b/test/DMLibTest/Util/DMLibTestStream.cs
@@ -1,0 +1,96 @@
+﻿
+
+namespace DMLibTest.Util
+{
+    using System;
+    using System.IO;
+
+    class DMLibTestStream : Stream
+    {
+        FileStream internalStream = null;
+        bool seekable;
+        bool fixedSize;
+
+        public DMLibTestStream(FileStream stream, bool seekable = true, bool fixedSize = true)
+        {
+            this.internalStream = stream;
+            this.seekable = seekable;
+            this.fixedSize = fixedSize;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanWrite => true;
+        public override bool CanSeek => this.seekable;
+        public override long Position
+        {
+            get
+            {
+                if (this.seekable)
+                {
+                    return this.internalStream.Position;
+                }
+
+                throw new InvalidOperationException();
+            }
+
+            set
+            {
+                if (this.seekable)
+                {
+                    this.internalStream.Position = value;
+                }
+
+                throw new InvalidOperationException();
+            }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                if (fixedSize)
+                {
+                    return this.internalStream.Length;
+                }
+
+                throw new InvalidOperationException();
+            }
+        }
+
+        public override void Flush()
+        {
+            this.internalStream.Flush();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (this.seekable)
+            {
+                return this.internalStream.Seek(offset, origin);
+            }
+
+            throw new InvalidOperationException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return this.internalStream.Read(buffer, offset, count);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            this.internalStream.Write(buffer, offset, count);
+        }
+
+        public override void Close()
+        {
+            base.Close();
+            this.internalStream.Close();
+        }
+    }
+}

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.6.6.0")]
-[assembly: AssemblyFileVersion("0.6.6.0")]
+[assembly: AssemblyVersion("0.7.0.0")]
+[assembly: AssemblyFileVersion("0.7.0.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>0.6.6</version>
+    <version>0.7.0</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -22,6 +22,7 @@
         <dependency id="WindowsAzure.Storage" version="8.6.0" />
       </group>
       <group targetFramework="netstandard2.0">
+        <dependency id="Mono.Posix.NETStandard" version="1.0.0-beta2" />
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="WindowsAzure.Storage" version="8.6.0" />
         <dependency id="System.Dynamic.Runtime" version="4.3.0" />


### PR DESCRIPTION
1. Implement uploading from non-seekable stream
2. Implement follow-symlink
3. Fix issue of '/' is not escaped correctly when using other char as delimiter.
4. Escape continuous / in file name 
5. Fix an issue that "/" at the blob name end is not escaped during download.