### PR TITLE
Fix off by one error for MD5HashStream

### DIFF
--- a/lib/MD5HashStream.cs
+++ b/lib/MD5HashStream.cs
@@ -391,7 +391,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
                 //TODO: Duplication of code
                 var currentChunk = 0;
-                var currentChunkOffset = 1;
+                var currentChunkOffset = 0;
 
                 // Seek to the correct chunk and offset
                 while (offset != 0 && currentChunk != buffers.Length)


### PR DESCRIPTION
I was working on some prototype changes today and ran into this bug. It writes all but the first byte of the buffers for every call