### PR TITLE
Improve download performance by requesting larger range sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,7 @@ FakesAssemblies/
 # DNX
 project.lock.json
 artifacts/
+
+# Vim swap files
+.*.swp
+.*.swo

--- a/lib/Constants.cs
+++ b/lib/Constants.cs
@@ -30,6 +30,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         public const int DefaultMemoryChunkSize = 4 * 1024 * 1024;
 
         /// <summary>
+        /// Max size supported for transactional md5 checking, 4MB.
+        /// </summary>
+        public const int MaxTransactionalMD5Size = 4 * 1024 * 1024;
+
+        /// <summary>
         /// Maximum windows file path is 260 characters, including a terminating NULL characters.
         /// This leaves 259 useable characters.
         /// </summary>

--- a/lib/DataMovement.csproj
+++ b/lib/DataMovement.csproj
@@ -81,6 +81,7 @@
     <Compile Include="FileNativeMethods.cs" />
     <Compile Include="LongPathFile.cs" />
     <Compile Include="LongPathFileStream.cs" />
+    <Compile Include="PipelineMemoryStream.cs" />
     <Compile Include="TestHook\FaultInjectionPoint.cs" />
     <Compile Include="DirectoryTransferContext.cs" />
     <Compile Include="Interop\Interop.cs" />
@@ -185,6 +186,7 @@
     <Compile Include="TransferOptions\DirectoryOptions.cs" />
     <Compile Include="TransferOptions\DownloadDirectoryOptions.cs" />
     <Compile Include="TransferOptions\UploadDirectoryOptions.cs" />
+    <Compile Include="TransferPacer.cs" />
     <Compile Include="TransferStatus.cs" />
     <Compile Include="TransferScheduler.cs" />
     <Compile Include="TransferConfigurations.cs" />

--- a/lib/MD5HashStream.cs
+++ b/lib/MD5HashStream.cs
@@ -391,7 +391,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
                 //TODO: Duplication of code
                 var currentChunk = 0;
-                var currentChunkOffset = 1;
+                var currentChunkOffset = 0;
 
                 // Seek to the correct chunk and offset
                 while (offset != 0 && currentChunk != buffers.Length)

--- a/lib/PipelineMemoryStream.cs
+++ b/lib/PipelineMemoryStream.cs
@@ -24,7 +24,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         private MemoryManager manager;
         private Action<byte[], int, int> callback;
 
-        public PipelineMemoryStream(IMemoryManager manager, Action<byte[], int, int> callback)
+        public PipelineMemoryStream(MemoryManager manager, Action<byte[], int, int> callback)
         {
             this.buffer = manager.RequireBuffer();
             Debug.Assert(this.buffer != null); // TODO: Handle null return

--- a/lib/PipelineMemoryStream.cs
+++ b/lib/PipelineMemoryStream.cs
@@ -1,0 +1,142 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="PipelinedMemoryStream.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.WindowsAzure.Storage.DataMovement
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Collections.Generic;
+
+    // The following class is designed under the assumption that writes much are smaller on average than the buffer-size
+    // It is still correct without this assumption, but it's performance could be improved
+    // This is almost certainly a fair assumption for buffer-sizes >= 4 MB (the default)
+
+    internal class PipelineMemoryStream : Stream
+    {
+        private byte[] buffer;
+        private int length;      // including data which has been returned
+        private int offset;      // within the private buffer
+
+        private MemoryManager manager;
+        private Action<byte[], int, int> callback;
+
+        public PipelineMemoryStream(IMemoryManager manager, Action<byte[], int, int> callback)
+        {
+            this.buffer = manager.RequireBuffer();
+            Debug.Assert(this.buffer != null); // TODO: Handle null return
+            this.length = buffer.Length;
+            this.manager = manager;
+            this.callback = callback;
+        }
+
+        public override void Flush()
+        {
+            if (this.offset > 0) {
+                // After this call, the receiver owns the sent buffer
+                this.callback(this.buffer, 0, this.offset);
+                this.length += this.offset;
+                this.offset = 0;
+
+                // Get a new buffer to continue writing data
+                this.buffer = this.manager.RequireBuffer();
+                Debug.Assert(this.buffer != null); // TODO: Handle null return
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (offset < 0 || count < 0 || buffer.Length - offset < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+
+            int remaining = count;
+            int availible = this.buffer.Length - this.offset;
+
+            while (remaining > 0)
+            {
+                // Find n: The bytes to be written on this iteration
+                int n = remaining;
+                if (n > availible) {
+                    n = availible;
+                }
+
+                //Write n bytes to the current chunk
+                Array.Copy(buffer, offset, this.buffer, this.offset, n);
+                offset += n;
+                this.offset += n;
+                remaining -= n;
+
+                // If we have just filled our internal buffer, flush
+                availible = this.buffer.Length - this.offset;
+                if (availible == 0) {
+                    this.Flush();
+                    availible = this.buffer.Length;
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.manager.ReleaseBuffer(this.buffer);
+                this.buffer = null;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override long Length
+        {
+            get { return this.length; }
+        }
+
+        public override long Position
+        {
+            get { return this.length - this.buffer.Length + this.offset; }
+            set { throw new NotSupportedException(); }
+        }
+
+        // Unsupported methods
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/lib/PipelineMemoryStream.cs
+++ b/lib/PipelineMemoryStream.cs
@@ -12,17 +12,26 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
     using System.Collections.Generic;
     using System.Threading;
 
-    // The following class is designed under the assumption that writes much are smaller on average than the buffer-size
-    // It is still correct without this assumption, but it's performance could be improved
-    // This is almost certainly a fair assumption for buffer-sizes >= 4 MB (the default)
-
+    /// <summary>
+    /// A memory stream class designed to act as a data pipeline
+    /// Data written to this stream fills a segmented buffer. As each segment is filled it is passed to data receiver via
+    /// a callback. This callback effectively transfers owenership of the buffer to the receiver, allowing it to be used
+    /// and returned to the buffer pool.
+    /// </summary>
+    /// <remarks>
+    /// The following class is designed under the assumption that writes much are smaller on average than the buffer-size
+    /// It is still correct without this assumption, but it's performance could be improved
+    /// This is almost certainly a fair assumption for buffer-sizes >= 4 MB (the default)
+    ///
+    /// Any unused buffer segments will be released to the <c>MemoryManager</c> provided on construction when <c>Dispose</c> is called
+    /// </remarks>
     internal class PipelineMemoryStream : Stream
     {
         private byte[][] buffers = null;
-        private int index = 0;    // of the current buffer
-        private int length = 0;   // including data which has been returned
-        private int offset = 0;   // within current private buffer
-        private int position = 0; // across all buffers
+        private int index = 0;       // index of the current buffer
+        private int length = 0;      // total amount of buffer space in this stream
+        private int writeOffset = 0; // offset within current private buffer
+        private int position = 0;    // position as an offset from the start of all buffer space
 
         private MemoryManager manager; // Used to return unused buffers
         private Action<byte[], int, int> callback;
@@ -41,15 +50,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
         public override void Flush()
         {
-            if (this.offset > 0) {
+            if (this.writeOffset > 0) {
                 // After this call, the receiver owns the sent buffer
-                this.callback(this.buffers[this.index], 0, this.offset);
+                this.callback(this.buffers[this.index], 0, this.writeOffset);
 
                 // Move position forward by the remaining buffer length
                 // Any unsued space in the sent buffer is lost to us
-                this.position += this.buffers[this.index].Length - this.offset;
+                this.position += this.buffers[this.index].Length - this.writeOffset;
                 this.buffers[this.index] = null;
-                this.offset = 0;
+                this.writeOffset = 0;
                 this.index += 1;
             }
         }
@@ -77,7 +86,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             while (remaining > 0)
             {
-                int availible = this.buffers[this.index].Length - this.offset;
+                int availible = this.buffers[this.index].Length - this.writeOffset;
                 if (availible <= 0) {
                     this.Flush();
                     availible = this.buffers[this.index].Length;
@@ -87,9 +96,9 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                 int n = remaining > availible ? availible : remaining;
 
                 //Write n bytes to the current chunk
-                Array.Copy(buffer, offset, this.buffers[this.index], this.offset, n);
+                Array.Copy(buffer, offset, this.buffers[this.index], this.writeOffset, n);
                 offset += n;
-                this.offset += n;
+                this.writeOffset += n;
                 this.position += n;
                 remaining -= n;
             }

--- a/lib/PipelineMemoryStream.cs
+++ b/lib/PipelineMemoryStream.cs
@@ -55,7 +55,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                     }
                     else
                     {
-                        // TODO: This doesn't seem to exit the transfer so much as make it get stuck :(
                         throw new TransferException(TransferErrorCode.FailToAllocateMemory);
                     }
                 }
@@ -76,6 +75,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
         public override void Write(byte[] buffer, int offset, int count)
         {
+            if (this.buffer == null)
+            {
+                ReplaceBuffer();
+            }
+
             if (buffer == null)
             {
                 throw new ArgumentNullException(nameof(buffer));
@@ -85,7 +89,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
-
 
             int remaining = count;
             int availible = this.buffer.Length - this.offset;
@@ -117,8 +120,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             if (disposing)
             {
-                this.manager.ReleaseBuffer(this.buffer);
-                this.buffer = null;
+                if (this.buffer != null)
+                {
+                    this.manager.ReleaseBuffer(this.buffer);
+                    this.buffer = null;
+                }
             }
 
             base.Dispose(disposing);

--- a/lib/PipelineMemoryStream.cs
+++ b/lib/PipelineMemoryStream.cs
@@ -49,14 +49,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                 {
                     if (remaining > 0)
                     {
-                        Console.WriteLine($"Backing off for {sleepTime} hot milliseconds");
                         Thread.Sleep((int)Math.Min(sleepTime, remaining));
                         remaining -= sleepTime;
                         sleepTime *= 2;
                     }
                     else
                     {
-                        Console.WriteLine($"THROW!!");
+                        // TODO: This doesn't seem to exit the transfer so much as make it get stuck :(
                         throw new TransferException(TransferErrorCode.FailToAllocateMemory);
                     }
                 }

--- a/lib/PipelineMemoryStream.cs
+++ b/lib/PipelineMemoryStream.cs
@@ -68,8 +68,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             // Check if we can fit this data in the remaining buffers
             if (this.index >= this.buffers.Length || count > (this.length - this.position))
             {
-                // TODO: Add an error message
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(Resources.InsufficientBufferSpaceException);
             }
 
             if (buffer == null)

--- a/lib/PipelineMemoryStream.cs
+++ b/lib/PipelineMemoryStream.cs
@@ -24,11 +24,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         private int offset = 0;   // within current private buffer
         private int position = 0; // across all buffers
 
+        private MemoryManager manager; // Used to return unused buffers
         private Action<byte[], int, int> callback;
 
-        public PipelineMemoryStream(byte[][] buffers, Action<byte[], int, int> callback)
+        public PipelineMemoryStream(byte[][] buffers, MemoryManager manager, Action<byte[], int, int> callback)
         {
             this.buffers = buffers;
+            this.manager = manager;
             this.callback = callback;
 
             foreach (var buffer in buffers)
@@ -95,6 +97,19 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
         protected override void Dispose(bool disposing)
         {
+
+            if (this.buffers != null && this.manager != null)
+            {
+                for (int i=0; i< this.buffers.Length; i++)
+                {
+                    if (this.buffers[i] != null)
+                    {
+                        this.manager.ReleaseBuffer(this.buffers[i]);
+                        this.buffers[i] = null;
+                    }
+                }
+            }
+
             base.Dispose(disposing);
         }
 

--- a/lib/PipelineMemoryStream.cs
+++ b/lib/PipelineMemoryStream.cs
@@ -13,18 +13,20 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
     using System.Threading;
 
     /// <summary>
-    /// A memory stream class designed to act as a data pipeline
+    /// A memory stream class designed to act as a data pipeline.
     /// Data written to this stream fills a segmented buffer. As each segment is filled it is passed to data receiver via
     /// a callback. This callback effectively transfers owenership of the buffer to the receiver, allowing it to be used
     /// and returned to the buffer pool.
     /// </summary>
-    /// <remarks>
-    /// The following class is designed under the assumption that writes much are smaller on average than the buffer-size
-    /// It is still correct without this assumption, but it's performance could be improved
-    /// This is almost certainly a fair assumption for buffer-sizes >= 4 MB (the default)
-    ///
+    /// <remarks><para>
+    /// The following class is designed under the assumption that writes much are smaller on average than the buffer-size.
+    /// It is still correct without this assumption, but it's performance could be improved.
+    /// This is almost certainly a fair assumption for buffer-sizes >= 4 MB. (the default)
+    /// </para><para>
+    /// This stream is non-seekable, cannot be expanded, and does not support reads.
+    /// </para><para>
     /// Any unused buffer segments will be released to the <c>MemoryManager</c> provided on construction when <c>Dispose</c> is called
-    /// </remarks>
+    /// </para></remarks>
     internal class PipelineMemoryStream : Stream
     {
         private byte[][] buffers = null;
@@ -36,6 +38,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         private MemoryManager manager; // Used to return unused buffers
         private Action<byte[], int, int> callback;
 
+        /// <summary>
+        /// Constructs a memory stream class designed to act as a data pipeline.
+        /// </summary>
+        /// <param name="buffers">The segmented buffer which will be filled by this stream</param>
+        /// <param name="manager">The <c>MemoryManager</c> to which unused buffers will be released on <c>Dispose</c></param>
+        /// <param name="callback">The callback which will receive buffers with written data</param>
         public PipelineMemoryStream(byte[][] buffers, MemoryManager manager, Action<byte[], int, int> callback)
         {
             this.buffers = buffers;
@@ -48,6 +56,9 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
         }
 
+        /// <summary>
+        /// Immedietly sends the current buffer segment to the callback.
+        /// </summary>
         public override void Flush()
         {
             if (this.writeOffset > 0) {
@@ -63,6 +74,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
         }
 
+        /// <summary>
+        /// Write data to the streams internal buffer.
+        /// A buffer segment may be sent to the callback if it becomes full.
+        /// </summary>
+        /// <param name="buffer">An array of bytes from which data will be copied</param>
+        /// <param name="offset">The offset within the buffer to start copying</param>
+        /// <param name="count">The number of bytes to copy</param>
         public override void Write(byte[] buffer, int offset, int count)
         {
             // Check if we can fit this data in the remaining buffers
@@ -121,26 +139,41 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             base.Dispose(disposing);
         }
 
+        /// <summary>
+        /// Indicates if this stream can be read from (false)
+        /// </summary>
         public override bool CanRead
         {
             get { return false; }
         }
 
+        /// <summary>
+        /// Indicates if this stream can seek (false)
+        /// </summary>
         public override bool CanSeek
         {
             get { return false; }
         }
 
+        /// <summary>
+        /// Indicates if this stream can be written to (true)
+        /// </summary>
         public override bool CanWrite
         {
             get { return true; }
         }
 
+        /// <summary>
+        /// The total length of the streams internal buffer
+        /// </summary>
         public override long Length
         {
             get { return this.length; }
         }
 
+        /// <summary>
+        /// The writting position of the stream
+        /// </summary>
         public override long Position
         {
             get { return this.position; }
@@ -148,16 +181,25 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         }
 
         // Unsupported methods
+        /// <summary>
+        /// Unsupported
+        /// </summary>
         public override long Seek(long offset, SeekOrigin origin)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Unsupported
+        /// </summary>
         public override void SetLength(long value)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Unsupported
+        /// </summary>
         public override int Read(byte[] buffer, int offset, int count)
         {
             throw new NotSupportedException();

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -727,5 +727,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
                 return ResourceManager.GetString("UnsupportedTransferLocationException", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Not enough buffer space to write the requested data
+        /// </summary>
+        internal static string InsufficientBufferSpaceException {
+            get {
+                return ResourceManager.GetString("InsufficientBufferSpaceException", resourceCulture);
+            }
+        }
     }
 }

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -382,4 +382,7 @@ MD5 in property: {2}</value>
   <data name="ResumeStreamTransferNotSupported" xml:space="preserve">
     <value>Resuming transfer from or to a stream is not supported. </value>
   </data>
+  <data name="InsufficientBufferSpaceException" xml:space="preserve">
+    <value>Not enough buffer space to write the requested data</value>
+  </data>
 </root>

--- a/lib/TransferControllers/SyncTransferController.cs
+++ b/lib/TransferControllers/SyncTransferController.cs
@@ -36,8 +36,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
             this.SharedTransferData = new SharedTransferData()
             {
-                TransferJob = this.TransferJob,
-                AvailableData = new ConcurrentDictionary<long, TransferData>(),
+                TransferJob = this.TransferJob
             };
 
             if (null == transferJob.CheckPoint)
@@ -48,7 +47,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             this.reader = this.GetReader(transferJob.Source);
             this.writer = this.GetWriter(transferJob.Destination);
 
-            this.SharedTransferData.OnTotalLengthChanged += (sender, args) =>
+            this.SharedTransferData.TotalLengthChanged += (sender, e) =>
             {
                 // For large block blob uploading, we need to re-calculate the BlockSize according to the total size
                 // The formula: Ceiling(TotalSize / (50000 * DefaultBlockSize)) * DefaultBlockSize. This will make sure the
@@ -213,12 +212,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
                 this.writer?.Dispose();
 
-                foreach(var transferData in this.SharedTransferData.AvailableData.Values)
+                foreach(var transferData in this.SharedTransferData.Values)
                 {
                     transferData.Dispose();
                 }
 
-                this.SharedTransferData.AvailableData.Clear();
+                this.SharedTransferData.Clear();
             }
         }
     }

--- a/lib/TransferControllers/SyncTransferController.cs
+++ b/lib/TransferControllers/SyncTransferController.cs
@@ -19,8 +19,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
         private readonly TransferReaderWriterBase writer;
 
         public SyncTransferController(
-            TransferScheduler transferScheduler, 
-            TransferJob transferJob, 
+            TransferScheduler transferScheduler,
+            TransferJob transferJob,
             CancellationToken userCancellationToken)
             : base(transferScheduler, transferJob, userCancellationToken)
         {
@@ -36,8 +36,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
             this.SharedTransferData = new SharedTransferData()
             {
-                TransferJob = this.TransferJob, 
-                AvailableData = new ConcurrentDictionary<long, TransferData>(), 
+                TransferJob = this.TransferJob,
+                AvailableData = new ConcurrentDictionary<long, TransferData>(),
             };
 
             if (null == transferJob.CheckPoint)
@@ -51,37 +51,26 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             this.SharedTransferData.OnTotalLengthChanged += (sender, args) =>
             {
                 // For large block blob uploading, we need to re-calculate the BlockSize according to the total size
-                // The formula: Ceiling(TotalSize / (50000 * DefaultBlockSize)) * DefaultBlockSize. This will make sure the 
+                // The formula: Ceiling(TotalSize / (50000 * DefaultBlockSize)) * DefaultBlockSize. This will make sure the
                 // new block size will be mutiple of DefaultBlockSize(aka MemoryManager's chunk size)
-                if (this.writer is BlockBlobWriter)
+                var normalMaxBlockBlobSize = (long)50000 * Constants.DefaultBlockSize;
+
+                // Calculate the min block size according to the blob total length
+                var memoryChunksRequiredEachTime = (int)Math.Ceiling((double)this.SharedTransferData.TotalLength / normalMaxBlockBlobSize);
+                var blockSize = memoryChunksRequiredEachTime * TransferManager.Configurations.MemoryChunkSize;
+
+                if (TransferManager.Configurations.BlockSize > blockSize)
                 {
-                    var normalMaxBlockBlobSize = (long)50000 * Constants.DefaultBlockSize;
-
-                    // Calculate the min block size according to the blob total length
-                    var memoryChunksRequiredEachTime = (int)Math.Ceiling((double)this.SharedTransferData.TotalLength / normalMaxBlockBlobSize);
-                    var blockSize = memoryChunksRequiredEachTime * Constants.DefaultBlockSize;
-
-                    if (TransferManager.Configurations.BlockSize > blockSize)
-                    {
-                        // Take the block size user specified when it's greater than the calculated value
-                        blockSize = TransferManager.Configurations.BlockSize;
-                        memoryChunksRequiredEachTime = (int)Math.Ceiling((double)blockSize / Constants.DefaultBlockSize);
-                    }
-                    else
-                    {
-                        // Try to increase the memory pool size
-                        this.Scheduler.TransferOptions.UpdateMaximumCacheSize(blockSize);
-                    }
-
-                    this.SharedTransferData.BlockSize = blockSize;
-                    this.SharedTransferData.MemoryChunksRequiredEachTime = memoryChunksRequiredEachTime;
+                    // Take the block size user specified when it's greater than the calculated value
+                    blockSize = TransferManager.Configurations.BlockSize;
+                    memoryChunksRequiredEachTime = (int)Math.Ceiling((double)blockSize / TransferManager.Configurations.MemoryChunkSize);
                 }
-                else
-                {
-                    // For normal directions, we'll use default block size 4MB for transfer.
-                    this.SharedTransferData.BlockSize = Constants.DefaultBlockSize;
-                    this.SharedTransferData.MemoryChunksRequiredEachTime = 1;
-                }
+
+                // Try to increase the memory pool size
+                this.Scheduler.TransferOptions.UpdateMaximumCacheSize(blockSize);
+
+                this.SharedTransferData.BlockSize = blockSize;
+                this.SharedTransferData.MemoryChunksRequiredEachTime = memoryChunksRequiredEachTime;
             };
         }
 
@@ -154,12 +143,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                     {
                         return new BlockBasedBlobReader(this.Scheduler, this, this.CancellationToken);
                     }
-                    else 
+                    else
                     {
                         throw new InvalidOperationException(
                             string.Format(
-                            CultureInfo.CurrentCulture, 
-                            Resources.UnsupportedBlobTypeException, 
+                            CultureInfo.CurrentCulture,
+                            Resources.UnsupportedBlobTypeException,
                             sourceBlob.BlobType));
                     }
                 case TransferLocationType.AzureFile:
@@ -167,8 +156,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                 default:
                     throw new InvalidOperationException(
                         string.Format(
-                        CultureInfo.CurrentCulture, 
-                        Resources.UnsupportedTransferLocationException, 
+                        CultureInfo.CurrentCulture,
+                        Resources.UnsupportedTransferLocationException,
                         sourceLocation.Type));
             }
         }
@@ -199,8 +188,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                     {
                         throw new InvalidOperationException(
                             string.Format(
-                            CultureInfo.CurrentCulture, 
-                            Resources.UnsupportedBlobTypeException, 
+                            CultureInfo.CurrentCulture,
+                            Resources.UnsupportedBlobTypeException,
                             destBlob.BlobType));
                     }
                 case TransferLocationType.AzureFile:
@@ -208,8 +197,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                 default:
                     throw new InvalidOperationException(
                         string.Format(
-                        CultureInfo.CurrentCulture, 
-                        Resources.UnsupportedTransferLocationException, 
+                        CultureInfo.CurrentCulture,
+                        Resources.UnsupportedTransferLocationException,
                         destLocation.Type));
             }
         }

--- a/lib/TransferControllers/TransferReaderWriterBase.cs
+++ b/lib/TransferControllers/TransferReaderWriterBase.cs
@@ -95,13 +95,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
         public TransferData GetFirstAvailable()
         {
             TransferData transferData = null;
-            var transferDatas = this.SharedTransferData.AvailableData.Values;
+            var transferDatas = this.SharedTransferData.Values;
 
             if (transferDatas.Any())
             {
                 transferData = transferDatas.First();
                 TransferData tempData;
-                this.SharedTransferData.AvailableData.TryRemove(transferData.StartOffset, out tempData);
+                this.SharedTransferData.TryRemove(transferData.StartOffset, out tempData);
                 return transferData;
             }
 

--- a/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
+++ b/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
@@ -220,13 +220,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             }
             else
             {
-                rangeRequestSize = (int)Math.Max(this.Scheduler.Pacer.RangeRequestSize, this.SharedTransferData.BlockSize);
+                rangeRequestSize = (int)Math.Min(this.SharedTransferData.TotalLength - this.transferJob.CheckPoint.EntryTransferOffset, this.Scheduler.Pacer.RangeRequestSize);
+                rangeRequestSize = (int)Math.Max(rangeRequestSize, this.SharedTransferData.BlockSize);
             }
 
             // Round down effectiveBlock size to the nearest memory chunk size
             rangeRequestSize = (rangeRequestSize / this.Scheduler.TransferOptions.MemoryChunkSize) * this.Scheduler.TransferOptions.MemoryChunkSize;
-
-            // TODO: Try to delay this allocation to avoid failures
             var memoryBuffer = this.Scheduler.MemoryManager.RequireBuffers(rangeRequestSize / this.Scheduler.TransferOptions.MemoryChunkSize);
 
             if (null != memoryBuffer)

--- a/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
+++ b/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
@@ -214,7 +214,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             this.hasWork = false;
 
             int rangeRequestSize = 0;
-            if (useFallback)
+            if (useFallback || !this.IsTransferWindowEmpty())
             {
                 rangeRequestSize = this.SharedTransferData.BlockSize;
             }
@@ -235,7 +235,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
                 if (!this.IsTransferWindowEmpty())
                 {
-                    // TODO: Now that BlockSize is highly variable, this may not be correct
                     startOffset = this.lastTransferWindow.Dequeue();
                 }
                 else

--- a/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
+++ b/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
@@ -214,7 +214,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             this.hasWork = false;
 
             int rangeRequestSize = 0;
-            if (useFallback || !this.IsTransferWindowEmpty() || (this.sourceLocation.BlobRequestOptions.UseTransactionalMD5 ?? true))
+            if (useFallback || !this.IsTransferWindowEmpty())
             {
                 rangeRequestSize = this.SharedTransferData.BlockSize;
             }
@@ -222,6 +222,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             {
                 rangeRequestSize = (int)Math.Min(this.SharedTransferData.TotalLength - this.transferJob.CheckPoint.EntryTransferOffset, this.Scheduler.Pacer.RangeRequestSize);
                 rangeRequestSize = (int)Math.Max(rangeRequestSize, this.SharedTransferData.BlockSize);
+            }
+            if (this.sourceLocation.BlobRequestOptions.UseTransactionalMD5 ?? true)
+            {
+                rangeRequestSize = (int)Math.Min(rangeRequestSize, Constants.MaxTransactionalMD5Size);
             }
 
             // Round down effectiveBlock size to the nearest memory chunk size

--- a/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
+++ b/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
@@ -333,11 +333,9 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                  this.sourceBlob.Properties.ETag,
                  this.sourceLocation.AccessCondition);
 
-            if (useFallback)
+            if (null != asyncState.MemoryBuffer)
             {
-                // TODO: Address case in which the memory buffer is null
-                // e.g. the useFallback flag was flipped just before this "if"
-                Debug.Assert(null != asyncState.MemoryBuffer);
+                // This is the fallback code path
                 if (asyncState.MemoryBuffer.Length == 1)
                 {
                     // We're to download this block.
@@ -386,9 +384,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             }
             else
             {
-                // TODO: See above, but this time the concern is memory leaks
-                Debug.Assert(null == asyncState.MemoryBuffer);
-
                 try
                 {
                     var stream = new PipelineMemoryStream (

--- a/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
+++ b/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
@@ -363,6 +363,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             {
                 var stream = new PipelineMemoryStream (
                     asyncState.MemoryBuffer,
+                    asyncState.MemoryManager,
                     (byte[] buffer, int offset, int count) => {
                         Debug.Assert(offset == 0); // In our case this should always be zero
                         TransferData transferData = new TransferData(asyncState.MemoryManager)

--- a/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
+++ b/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
@@ -238,7 +238,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
                 if (!this.IsTransferWindowEmpty())
                 {
-                    // TODO: This is wrong. This block size needs to be set here
+                    // TODO: Now that BlockSize is highly variable, this may not be correct
                     startOffset = this.lastTransferWindow.Dequeue();
                 }
                 else

--- a/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
+++ b/lib/TransferControllers/TransferReaders/BlockBasedBlobReader.cs
@@ -214,7 +214,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             this.hasWork = false;
 
             int rangeRequestSize = 0;
-            if (useFallback || !this.IsTransferWindowEmpty())
+            if (useFallback || !this.IsTransferWindowEmpty() || (this.sourceLocation.BlobRequestOptions.UseTransactionalMD5 ?? true))
             {
                 rangeRequestSize = this.SharedTransferData.BlockSize;
             }

--- a/lib/TransferControllers/TransferReaders/RangeBasedReader.cs
+++ b/lib/TransferControllers/TransferReaders/RangeBasedReader.cs
@@ -439,7 +439,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                         MemoryBuffer = buffer.MemoryBuffer
                     };
 
-                    this.SharedTransferData.AvailableData.TryAdd(buffer.StartOffset, transferData);
+                    this.SharedTransferData.TryAdd(buffer.StartOffset, transferData);
                 }
             }
         }

--- a/lib/TransferControllers/TransferReaders/StreamedReader.cs
+++ b/lib/TransferControllers/TransferReaders/StreamedReader.cs
@@ -425,7 +425,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             }
 
             asyncState.MemoryBuffer = null;
-            this.SharedTransferData.AvailableData.TryAdd(transferData.StartOffset, transferData);
+            this.SharedTransferData.TryAdd(transferData.StartOffset, transferData);
 
             this.SetChunkFinish();
         }

--- a/lib/TransferControllers/TransferWriters/AppendBlobWriter.cs
+++ b/lib/TransferControllers/TransferWriters/AppendBlobWriter.cs
@@ -54,7 +54,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                 return this.hasWork &&
                     ((State.FetchAttributes == this.state) ||
                     (State.Create == this.state) ||
-                    (State.UploadBlob == this.state && this.SharedTransferData.AvailableData.ContainsKey(this.expectedOffset)) ||
+                    (State.UploadBlob == this.state && this.SharedTransferData.ContainsKey(this.expectedOffset)) ||
                     (State.Commit == this.state && null != this.SharedTransferData.Attributes));
             }
         }
@@ -283,7 +283,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             this.hasWork = false;
 
             TransferData transferData = null;
-            if (!this.SharedTransferData.AvailableData.TryRemove(this.expectedOffset, out transferData))
+            if (!this.SharedTransferData.TryRemove(this.expectedOffset, out transferData))
             {
                 this.hasWork = true;
                 return;

--- a/lib/TransferControllers/TransferWriters/BlockBlobWriter.cs
+++ b/lib/TransferControllers/TransferWriters/BlockBlobWriter.cs
@@ -63,9 +63,9 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
         public override bool HasWork => this.hasWork && 
                                         (!this.PreProcessed
-                                         || ((this.state == State.UploadBlob) && this.SharedTransferData.AvailableData.Any())
+                                         || ((this.state == State.UploadBlob) && !this.SharedTransferData.IsEmpty)
                                          || ((this.state == State.Commit) && (null != this.SharedTransferData.Attributes))
-                                         || ((this.state == State.UploadBlobAndSetAttributes) && this.SharedTransferData.AvailableData.Any() && null != this.SharedTransferData.Attributes));
+                                         || ((this.state == State.UploadBlobAndSetAttributes) && !this.SharedTransferData.IsEmpty && null != this.SharedTransferData.Attributes));
 
         public override bool IsFinished => State.Error == this.state || State.Finished == this.state;
 

--- a/lib/TransferControllers/TransferWriters/RangeBasedWriter.cs
+++ b/lib/TransferControllers/TransferWriters/RangeBasedWriter.cs
@@ -65,7 +65,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             {
                 return this.hasWork &&
                     (!this.PreProcessed
-                    || ((State.Upload == this.state) && this.SharedTransferData.AvailableData.Any())
+                    || ((State.Upload == this.state) && !this.SharedTransferData.IsEmpty)
                     || ((State.Commit == this.state) && (null != this.SharedTransferData.Attributes)));
             }
         }

--- a/lib/TransferControllers/TransferWriters/StreamedWriter.cs
+++ b/lib/TransferControllers/TransferWriters/StreamedWriter.cs
@@ -77,7 +77,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                     ((State.OpenOutputStream == this.state)
                     || (State.CalculateMD5 == this.state)
                     || ((State.Write == this.state)
-                        && ((this.SharedTransferData.TotalLength == this.expectOffset) || this.SharedTransferData.AvailableData.ContainsKey(this.expectOffset))));
+                        && ((this.SharedTransferData.TotalLength == this.expectOffset) || this.SharedTransferData.ContainsKey(this.expectOffset))));
             }
         }
 
@@ -265,7 +265,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             this.hasWork = false;
             long currentWriteOffset = this.expectOffset;
             TransferData transferData;
-            if (this.SharedTransferData.AvailableData.TryRemove(this.expectOffset, out transferData))
+            if (this.SharedTransferData.TryRemove(this.expectOffset, out transferData))
             {
                 this.expectOffset = Math.Min(this.expectOffset + transferData.Length, this.SharedTransferData.TotalLength);
             }

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -392,6 +392,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
                 BlobRequestOptions requestOptions = Transfer_RequestOptions.DefaultBlobRequestOptions;
                 requestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
+                requestOptions.UseTransactionalMD5 = options.UseTransactionalMD5;
                 sourceLocation.BlobRequestOptions = requestOptions;
             }
 
@@ -443,6 +444,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
                 BlobRequestOptions requestOptions = Transfer_RequestOptions.DefaultBlobRequestOptions;
                 requestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
+                requestOptions.UseTransactionalMD5 = options.UseTransactionalMD5;
                 sourceLocation.BlobRequestOptions = requestOptions;
             }
 

--- a/lib/TransferOptions/DownloadOptions.cs
+++ b/lib/TransferOptions/DownloadOptions.cs
@@ -21,5 +21,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// If not specified, it defaults to false.
         /// </summary>
         public bool DisableContentMD5Validation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag that indicates whether to validate the MD5 hash of each storage transaction
+        /// Any given download may be broken up into a number of transactions in which a piece of the source object is downloaded
+        /// If set to true, each transaction MD5 will be validated; otherwise, the transactions will not be validated
+        /// If not specified, it defaults to true
+        /// </summary>
+        public bool UseTransactionalMD5 { get; set; } = true;
     }
 }

--- a/lib/TransferPacer.cs
+++ b/lib/TransferPacer.cs
@@ -5,6 +5,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
     using System.Diagnostics;
     using System.Threading;
 
+    /// <summary>
+    /// <c>TransferPacer</c> takes in performance and state data and adjusts transfer parameters
+    /// This class will be a central point for the tuning of performance attributes
+    /// </summary>
     internal class TransferPacer
     {
         /// <summary>
@@ -12,7 +16,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// </summary>
         public TransferConfigurations Configurations { get; set; }
       
-        // Must occur before the controller is active
+        /// <summary>
+        /// Registers a <c>SyncTransferController</c> to be tracked by, and factored into pacing adjustments
+        /// </summary>
+        /// <remarks>
+        /// Must occur before the controller is active
+        /// </remarks>
         public void Register(SyncTransferController controller)
         {
             // Add the length to our total volume. 
@@ -24,8 +33,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             sharedData.TotalLengthChanged += lengthChangedHandler;
         }
 
-        // Must occur after the controller has stopped
-        // (i.e. No more events will be received)
+        /// <summary>
+        /// Deregisters a registered <c>SyncTransferController</c>
+        /// </summary>
+        /// <remarks>
+        /// Must occur after the controller has stopped (i.e. No more events will be received)
+        /// </remarks>
         public void Deregister(SyncTransferController controller)
         {
             // Subtract from scheduled volume any unread data
@@ -44,6 +57,9 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             sharedData.TotalLengthChanged -= lengthChangedHandler;
         }
         
+        /// <summary>
+        /// The tuned range size to request for HTTP GET download requests
+        /// </summary>
         public int RangeRequestSize {
             get
             {

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -46,8 +46,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
         }
 
-        public long ReadLength { get => this.readLength; }
-        public long WrittenLength { get => this.writtenLength; }
+        public long ReadLength { get => Interlocked.Read(ref readLength); }
+        public long WrittenLength { get => Interlocked.Read(ref writtenLength); }
 
         public int BlockSize { get; set; }
 
@@ -77,8 +77,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             if (success)
             {
                 Interlocked.Add(ref this.readLength, value.Length);
-                Debug.Assert(readLength <= TotalLength);
-                Debug.Assert(readLength >= WrittenLength);
+                Debug.Assert(Interlocked.Read(ref readLength) <= TotalLength);
+                Debug.Assert(Interlocked.Read(ref readLength) >= WrittenLength);
             }
 
             var handler = TransferDataAdded;
@@ -100,8 +100,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             if (success)
             {
                 Interlocked.Add(ref this.writtenLength, value.Length);
-                Debug.Assert(writtenLength <= TotalLength);
-                Debug.Assert(writtenLength <= ReadLength);
+                Debug.Assert(Interlocked.Read(ref writtenLength) <= TotalLength);
+                Debug.Assert(Interlocked.Read(ref writtenLength) <= ReadLength);
             }
 
             var handler = TransferDataRemoved;

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -47,6 +47,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         }
 
         public long ReadLength { get { return Interlocked.Read(ref readLength); } }
+
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public long WrittenLength { get { return Interlocked.Read(ref writtenLength); } }
 
         public int BlockSize { get; set; }
@@ -115,9 +117,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         }
 
         public bool ContainsKey(long key) => this.data.ContainsKey(key);
+
         public bool IsEmpty { get { return this.data.IsEmpty; } }
+
         public void Clear() => this.data.Clear();
+
         public ICollection<TransferData> Values { get { return this.data.Values; } }
+
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public ICollection<long> Keys { get { return this.data.Keys; } }
 
         public event EventHandler<ValueChangeEventArgs<long>> TotalLengthChanged;
@@ -134,7 +141,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
     internal class TransferDataEventArgs : EventArgs
     {
         public TransferData Data { get; set; }
+
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public long Offset { get; set; }
+
         public bool Success { get; set; }
     }
 }

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -6,11 +6,17 @@
 namespace Microsoft.WindowsAzure.Storage.DataMovement
 {
     using System;
+    using System.Diagnostics;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading;
 
     internal class SharedTransferData
     {
-        private long totalLength;
+        private long totalLength = 0;
+        private long readLength = 0;
+        private long writtenLength = 0;
+        private ConcurrentDictionary<long, TransferData> data = new ConcurrentDictionary<long, TransferData>();
 
         /// <summary>
         /// Gets or sets length of source.
@@ -20,12 +26,29 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             get { return this.totalLength; }
             set
             {
-                this.totalLength = value;
+                if (value < ReadLength)
+                {
+                    // TODO: Add an error message
+                    throw new ArgumentOutOfRangeException();
+                }
 
-                var handler = OnTotalLengthChanged;
-                handler?.Invoke(this, null);
+                // The order in which events are sent to the handler cannot be gaurenteed
+                // but we use Interlocked.Exchange to ensure the values are accurate
+                var old = Interlocked.Exchange(ref this.totalLength, value);
+
+                var handler = TotalLengthChanged;
+                if (handler != null)
+                {
+                    handler.Invoke(this, new ValueChangeEventArgs<long> {
+                        Old = old,
+                        New = value
+                    });
+                }
             }
         }
+
+        public long ReadLength { get => this.readLength; }
+        public long WrittenLength { get => this.writtenLength; }
 
         public int BlockSize { get; set; }
 
@@ -37,22 +60,84 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         public TransferJob TransferJob { get; set; }
 
         /// <summary>
-        /// Gets or sets list of available transfer data from source.
-        /// </summary>
-        public ConcurrentDictionary<long, TransferData> AvailableData { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether should disable validation of content md5.
         /// The reader should get this value from source's <c>RequestOptions</c>,
         /// the writer should do or not do validation on content md5 according to this value.
         /// </summary>
         public bool DisableContentMD5Validation { get; set; }
-        
+
         /// <summary>
         /// Gets or sets attribute for blob/azure file.
         /// </summary>
         public Attributes Attributes { get; set; }
 
-        public event EventHandler OnTotalLengthChanged;
+        public bool TryAdd(long key, TransferData value)
+        {
+            var success = this.data.TryAdd(key, value);
+
+            if (success)
+            {
+                Interlocked.Add(ref this.readLength, value.Length);
+                Debug.Assert(readLength <= TotalLength);
+                Debug.Assert(readLength >= WrittenLength);
+            }
+
+            var handler = TransferDataAdded;
+            if (handler != null)
+            {
+                handler.Invoke(this, new TransferDataEventArgs {
+                    Data = value,
+                    Offset = key,
+                    Success = success
+                });
+            }
+            return success;
+        }
+
+        public bool TryRemove(long key, out TransferData value)
+        {
+            var success = this.data.TryRemove(key, out value);
+
+            if (success)
+            {
+                Interlocked.Add(ref this.writtenLength, value.Length);
+                Debug.Assert(writtenLength <= TotalLength);
+                Debug.Assert(writtenLength <= ReadLength);
+            }
+
+            var handler = TransferDataRemoved;
+            if (handler != null)
+            {
+                handler.Invoke(this, new TransferDataEventArgs {
+                    Data = value,
+                    Offset = key,
+                    Success = success
+                });
+            }
+            return success;
+        }
+
+        public bool ContainsKey(long key) => this.data.ContainsKey(key);
+        public bool IsEmpty { get => this.data.IsEmpty; }
+        public void Clear() => this.data.Clear();
+        public ICollection<TransferData> Values { get => this.data.Values; }
+        public ICollection<long> Keys { get => this.data.Keys; }
+
+        public event EventHandler<ValueChangeEventArgs<long>> TotalLengthChanged;
+        public event EventHandler<TransferDataEventArgs> TransferDataAdded;
+        public event EventHandler<TransferDataEventArgs> TransferDataRemoved;
+    }
+
+    internal class ValueChangeEventArgs<T> : EventArgs
+    {
+        public T Old { get; set; }
+        public T New { get; set; }
+    }
+
+    internal class TransferDataEventArgs : EventArgs
+    {
+        public TransferData Data { get; set; }
+        public long Offset { get; set; }
+        public bool Success { get; set; }
     }
 }

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -28,8 +28,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             {
                 if (value < ReadLength)
                 {
-                    // TODO: Add an error message
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
                 // The order in which events are sent to the handler cannot be gaurenteed

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -46,13 +46,25 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
         }
 
+        /// <summary>
+        /// Gets the amount of data put into this <c>SharedTransferData</c> by the reader
+        /// </summary>
         public long ReadLength { get { return Interlocked.Read(ref readLength); } }
 
+        /// <summary>
+        /// Gets the amount of data taken out of this <c>SharedTransferData</c> by the writer
+        /// </summary>
         [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public long WrittenLength { get { return Interlocked.Read(ref writtenLength); } }
 
+        /// <summary>
+        /// Gets the set block size for this transfer
+        /// </summary>
         public int BlockSize { get; set; }
 
+        /// <summary>
+        /// Gets the memory chunks needed to hold <c>BlockSize</c> bytes of data
+        /// </summary>
         public int MemoryChunksRequiredEachTime { get; set; }
 
         /// <summary>
@@ -72,6 +84,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// </summary>
         public Attributes Attributes { get; set; }
 
+        /// <summary>
+        /// Attempt to add a new <c>TransferData</c> object to this dictionary-like store
+        /// </summary>
+        /// <param name="key">The start offset of the data</param>
+        /// <param name="value">The <c>TransferData</c> object which holds the data</param>
+        /// <returns>True if the <c>TransferData</c> was added. False otherwise</returns>
         public bool TryAdd(long key, TransferData value)
         {
             var success = this.data.TryAdd(key, value);
@@ -94,6 +112,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             return success;
         }
 
+        /// <summary>
+        /// Attempt remove a <c>TransferData</c> object from this dictionary-like store
+        /// </summary>
+        /// <param name="key">The start offset of the data</param>
+        /// <param name="value">The output reference for the retreived transfer data</param>
+        /// <returns>True is data was successfully removed. False otherwise</returns>
         public bool TryRemove(long key, out TransferData value)
         {
             var success = this.data.TryRemove(key, out value);
@@ -116,19 +140,47 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             return success;
         }
 
+        /// <summary>
+        /// Checks if a start offset is in this dictionary-like store
+        /// </summary>
+        /// <param name="key">The start offset</param>
+        /// <returns>True if data with that start offset is in the store</returns>
         public bool ContainsKey(long key) => this.data.ContainsKey(key);
 
+        /// <summary>
+        /// True if there is no transfer data in this object
+        /// </summary>
         public bool IsEmpty { get { return this.data.IsEmpty; } }
 
+        /// <summary>
+        /// Removes all transfer data from this object
+        /// </summary>
         public void Clear() => this.data.Clear();
 
+        /// <summary>
+        /// Gets a collection of <c>TransferData</c> objects stored
+        /// </summary>
         public ICollection<TransferData> Values { get { return this.data.Values; } }
 
+        /// <summary>
+        /// Gets a collection of start offsets stored
+        /// </summary>
         [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public ICollection<long> Keys { get { return this.data.Keys; } }
 
+        /// <summary>
+        /// Called when the <c>Length</c> property changes
+        /// </summary>
         public event EventHandler<ValueChangeEventArgs<long>> TotalLengthChanged;
+
+        /// <summary>
+        /// Called when transfer data is added
+        /// </summary>
         public event EventHandler<TransferDataEventArgs> TransferDataAdded;
+
+        /// <summary>
+        /// Called when transfer data is removed
+        /// </summary>
         public event EventHandler<TransferDataEventArgs> TransferDataRemoved;
     }
 

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -78,7 +78,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             {
                 Interlocked.Add(ref this.readLength, value.Length);
                 Debug.Assert(Interlocked.Read(ref readLength) <= TotalLength);
-                Debug.Assert(Interlocked.Read(ref readLength) >= WrittenLength);
             }
 
             var handler = TransferDataAdded;
@@ -101,7 +100,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             {
                 Interlocked.Add(ref this.writtenLength, value.Length);
                 Debug.Assert(Interlocked.Read(ref writtenLength) <= TotalLength);
-                Debug.Assert(Interlocked.Read(ref writtenLength) <= ReadLength);
             }
 
             var handler = TransferDataRemoved;

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -46,8 +46,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
         }
 
-        public long ReadLength { get => Interlocked.Read(ref readLength); }
-        public long WrittenLength { get => Interlocked.Read(ref writtenLength); }
+        public long ReadLength { get { return Interlocked.Read(ref readLength); } }
+        public long WrittenLength { get { return Interlocked.Read(ref writtenLength); } }
 
         public int BlockSize { get; set; }
 
@@ -115,10 +115,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         }
 
         public bool ContainsKey(long key) => this.data.ContainsKey(key);
-        public bool IsEmpty { get => this.data.IsEmpty; }
+        public bool IsEmpty { get { return this.data.IsEmpty; } }
         public void Clear() => this.data.Clear();
-        public ICollection<TransferData> Values { get => this.data.Values; }
-        public ICollection<long> Keys { get => this.data.Keys; }
+        public ICollection<TransferData> Values { get { return this.data.Values; } }
+        public ICollection<long> Keys { get { return this.data.Keys; } }
 
         public event EventHandler<ValueChangeEventArgs<long>> TotalLengthChanged;
         public event EventHandler<TransferDataEventArgs> TransferDataAdded;

--- a/lib/TransferStatusHelpers/TransferPacer.cs
+++ b/lib/TransferStatusHelpers/TransferPacer.cs
@@ -1,0 +1,64 @@
+namespace Microsoft.WindowsAzure.Storage.DataMovement
+{
+    using Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers;
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+
+    internal class TransferPacer
+    {
+        /// <summary>
+        /// Transfer options that this manager will pass to transfer controllers.
+        /// </summary>
+        public TransferConfigurations Configurations { get; set; }
+      
+        // Must occur before the controller is active
+        public void Register(SyncTransferController controller)
+        {
+            // Add the length to our total volume. 
+            // This is liely 0, but reasonably could be set before calling Register
+            var sharedData = controller.SharedTransferData;
+            Interlocked.Add(ref totalScheduledVolume, sharedData.TotalLength);
+            
+            sharedData.TransferDataAdded += dataAddedHandler;
+            sharedData.TotalLengthChanged += lengthChangedHandler;
+        }
+        
+        // Must occur after the controller has stopped
+        public void Deregister(SyncTransferController controller)
+        {
+            // Subtract from scheduled volume any unread data
+            var sharedData = controller.SharedTransferData;
+            Interlocked.Add(ref totalScheduledVolume, sharedData.ReadLength - sharedData.TotalLength);
+            Debug.Assert(totalScheduledVolume >= 0);
+            
+            sharedData.TransferDataAdded -= dataAddedHandler;
+            sharedData.TotalLengthChanged -= lengthChangedHandler;
+        }
+        
+        public int RangeRequestSize {
+            get
+            {
+                var value = this.totalScheduledVolume / Configurations.ParallelOperations;
+                return (int)Math.Max(Constants.MinBlockSize, Math.Min(value, Constants.MaxBlockSize));
+            }
+        }
+          
+        private long totalScheduledVolume = 0;
+        
+        private void dataAddedHandler(object sender, TransferDataEventArgs e)
+        {
+            if (e.Success)
+            {
+                Interlocked.Add(ref totalScheduledVolume, -(e.Data.Length));
+            }
+            Debug.Assert(totalScheduledVolume >= 0);
+        }
+        
+        private void lengthChangedHandler(object sender, ValueChangeEventArgs<long> e)
+        {
+            Interlocked.Add(ref totalScheduledVolume, e.New - e.Old);
+            Debug.Assert(totalScheduledVolume >= 0);
+        }
+    }
+}

--- a/lib/Transfer_RequestOptions.cs
+++ b/lib/Transfer_RequestOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         private const int DefaultRetryCountOtherError = 3;
 
         /// <summary>
-        /// Stores the default maximum execution time across all potential retries. 
+        /// Stores the default maximum execution time across all potential retries.
         /// </summary>
         private static readonly TimeSpan DefaultMaximumExecutionTime =
             TimeSpan.FromSeconds(900);
@@ -140,12 +140,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             /// </summary>
             private ExponentialRetry retryPolicy;
 
-#if !DOTNET5_4
             /// <summary>
             /// Indicate whether has met x-ms once or more.
             /// </summary>
             private bool gotXMsError = false;
-#endif
 
             /// <summary>
             /// Initializes a new instance of the <see cref="TransferRetryPolicy"/> class.
@@ -189,12 +187,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             /// Determines whether the operation should be retried and the interval until the next retry.
             /// </summary>
             /// <param name="retryContext">
-            /// A RetryContext object that indicates the number of retries, the results of the last request, 
+            /// A RetryContext object that indicates the number of retries, the results of the last request,
             /// and whether the next retry should happen in the primary or secondary location, and specifies the location mode.</param>
             /// <param name="operationContext">An OperationContext object for tracking the current operation.</param>
             /// <returns>
-            /// A RetryInfo object that indicates the location mode, 
-            /// and whether the next retry should happen in the primary or secondary location. 
+            /// A RetryInfo object that indicates the location mode,
+            /// and whether the next retry should happen in the primary or secondary location.
             /// If null, the operation will not be retried. </returns>
             public RetryInfo Evaluate(RetryContext retryContext, OperationContext operationContext)
             {
@@ -258,9 +256,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                 int currentRetryCount,
                 Exception lastException)
             {
-#if DOTNET5_4
-                return true;
-#else
                 if (this.gotXMsError)
                 {
                     return true;
@@ -299,6 +294,13 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                             }
                         }
                     }
+
+                    TransferException transferException = storageException.InnerException as TransferException;
+
+                    if (null != transferException)
+                    {
+                        return false;
+                    }
                 }
 
                 if (currentRetryCount < this.maxAttemptsOtherError)
@@ -307,7 +309,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                 }
 
                 return false;
-#endif
             }
         }
     }


### PR DESCRIPTION
I have been working for quite some time now on investigating and improving download performance. The main conclusion has been that when downloading many large files (the test case I have been using is 200 x 256 MB = 50 GB) the 4 MB block size requires too many requests and slows down download performance by up to 30% higher throughput

The changes presented in this PR include a number of modifications to enable large range requests when downloading. The PipelineMemoryStream is a major component of this which returns filled memory buffers in an asynchronously to allow writing those chunks to the final destination while a CloudBlob.DownloadRangeToStreamAsync is still running for a requested range.

In order to decide the correct range size to request the TransferPacer class is introduced. It tracks state information for the scheduler and tunes transfer parameters to optimize performance. With this PR it only tunes the RangeRequestSize, but is intended to be expandable to tune any other metrics as well.

At the time of posting this PR, it is not completely finished, but is close enough to review. Tasks I still need to complete include
* Provide a way to trigger fallback mode
* Decide how to adjust MaximumCacheSize
* ~~Fix a race condition which induces a deadlock~~
* ~~Ensure that journalling logic is still all valid~~

Additionally I need to run performance tests on the final version, but my past tests suggest the performance gains to 20 - 30% throughput gains

![200x256mb with autotuning](https://user-images.githubusercontent.com/5684286/38116975-761835ee-3367-11e8-8edd-3a47141e3dc0.JPG)

Update: Attached it a graph of my most recent test. It shows a ~65% improvement in download throughput