### PR TITLE
Reduce CPU usage from TransferScheduler

### DIFF
--- a/lib/TransferScheduler.cs
+++ b/lib/TransferScheduler.cs
@@ -342,6 +342,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                             this.controllerResetEvent = null;
                         }
 
+                        if (null != this.queueAddedEvent)
+                        {
+                            this.queueAddedEvent.Dispose();
+                            this.queueAddedEvent = null;
+                        }
+
                         this.memoryManager = null;
                     }
                 }

--- a/lib/TransferScheduler.cs
+++ b/lib/TransferScheduler.cs
@@ -364,6 +364,8 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             Task.Run(() =>
                 {
+                    var sw = new SpinWait();
+
                     while (!this.cancellationTokenSource.Token.IsCancellationRequested && !this.controllerQueue.IsCompleted)
                     {
                         // While there's work queuing or work that's been dequeue
@@ -379,7 +381,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
                                 // If we don't have the requested amount of active tasks
                                 // running, get a task item from any active transfer item
                                 // that has work available.
-                                this.DoWorkFrom(this.activeControllerItems);
+                                if (!this.DoWorkFrom(this.activeControllerItems))
+                                {
+                                    sw.SpinOnce();
+                                }
+                                else
+                                {
+                                    sw.Reset();
+                                }
                             }
                         }
 


### PR DESCRIPTION
To address issue: https://github.com/Azure/azure-storage-net-data-movement/issues/66

The task started by `TransferScheduler` spins waiting for work and consumes a lot of CPU even when there is nothing to do.  

* Introduce an event to block the task until more work is provided

Ideally the task would exit and a new task would be created when new work arrives but wanted to keep this change thin.

Other fixes considered:
1.  Adding a shutdown method to TransferManager : https://github.com/neilrees/azure-storage-net-data-movement/commit/2c718995b342f28a4ae344d842d7ddb56efa226c
But there's a potential race condition of one thread shutting down the transfer manager whilst someone else is adding more work.

2.  Also considered performing each interaction with DMLib in it's own app domain and shut down the domain when the upload is complete.  But the we loose the holistic view that `TransferManager` has of all the copies that we have going on.