### PR TITLE
Ehance error handling and add support to download from one Azure Blob/File to multiple streams

### DIFF
--- a/BreakingChanges.txt
+++ b/BreakingChanges.txt
@@ -1,3 +1,7 @@
+Tracking Breaking Changes since 0.8.1
+
+   - Change to overwrite destination's metadata with source's metadata in async copying instead of keeping destination's metadata
+
 Tracking Breaking Changes since 0.7.1
 
   - Changed following callbacks to asynchronized methods:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Microsoft Azure Storage Data Movement Library (0.8.1)
+# Microsoft Azure Storage Data Movement Library (0.9.0)
 
 The Microsoft Azure Storage Data Movement Library designed for high-performance uploading, downloading and copying Azure Storage Blob and File. This library is based on the core data movement framework that powers [AzCopy](https://azure.microsoft.com/documentation/articles/storage-use-azcopy/).
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+2018.10.25 Version 0.9.0
+ * All Services on both .Net Framework and .Net Core
+   - Upgrade azure storage client library to 9.3.2
+   - Enhance exception handling during enumeration to add more detailed error messages
+   - Disable transational MD5 on sync copying when using HTTPS protocol
+   - Change to overwrite destination's metadata with source's metadata in async copying instead of keeping destination's metadata
+   - Add support for download from the same Azure Blob/Azure File to different Stream intances with multiple transfer jobs
+
 2018.07.31 Version 0.8.1
  * All Services on both .Net Framework and .Net Core
    - Upgrade azure storage client library to 9.3.0

--- a/lib/DataMovement.csproj
+++ b/lib/DataMovement.csproj
@@ -58,8 +58,8 @@
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/lib/DirectoryTransferContext.cs
+++ b/lib/DirectoryTransferContext.cs
@@ -34,7 +34,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// Initializes a new instance of the <see cref="DirectoryTransferContext" /> class.
         /// </summary>
         /// <param name="journalStream">The stream into which the transfer journal info will be written into. 
-        /// It can resume the previours paused transfer from its journal stream.</param>
+        /// It can resume the previous paused transfer from its journal stream.</param>
         public DirectoryTransferContext(Stream journalStream)
             :base(journalStream)
         {

--- a/lib/TransferControllers/AsyncCopyControllers/BlobAsyncCopyController.cs
+++ b/lib/TransferControllers/AsyncCopyControllers/BlobAsyncCopyController.cs
@@ -88,6 +88,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
         {
             AccessCondition destAccessCondition = Utils.GenerateConditionWithCustomerCondition(this.destLocation.AccessCondition);
 
+            // To copy from source to blob, DataMovement Library should overwrite destination's properties and meta datas.
+            // Clear destination's meta data here to avoid using destination's meta data.
+            // Please reference to https://docs.microsoft.com/en-us/rest/api/storageservices/Copy-Blob.
+            this.destBlob.Metadata.Clear();
+
             if (null != this.SourceUri)
             {
                 return this.destBlob.StartCopyAsync(

--- a/lib/TransferControllers/AsyncCopyControllers/FileAsyncCopyController.cs
+++ b/lib/TransferControllers/AsyncCopyControllers/FileAsyncCopyController.cs
@@ -76,6 +76,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
         protected override Task<string> DoStartCopyAsync()
         {
+            // To copy from source to blob, DataMovement Library should overwrite destination's properties and meta datas.
+            // Clear destination's meta data here to avoid using destination's meta data.
+            // Please reference to https://docs.microsoft.com/en-us/rest/api/storageservices/copy-file.
+            this.destFile.Metadata.Clear();
+
             OperationContext operationContext = Utils.GenerateOperationContext(this.TransferContext);
             if (null != this.SourceUri)
             {

--- a/lib/TransferEnumerators/AzureBlobEntry.cs
+++ b/lib/TransferEnumerators/AzureBlobEntry.cs
@@ -33,5 +33,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
             get;
             private set;
         }
+
+        public override string ToString()
+        {
+            return Blob.ConvertToString();
+        }
     }
 }

--- a/lib/TransferEnumerators/AzureFileEntry.cs
+++ b/lib/TransferEnumerators/AzureFileEntry.cs
@@ -35,5 +35,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
             get;
             private set;
         }
+
+        public override string ToString()
+        {
+            return File.ConvertToString();
+        }
     }
 }

--- a/lib/TransferEnumerators/AzureFileEnumerator.cs
+++ b/lib/TransferEnumerators/AzureFileEnumerator.cs
@@ -230,7 +230,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                         string errorMessage = string.Format(
                             CultureInfo.CurrentCulture,
                             Resources.FailedToEnumerateDirectory,
-                            this.location.FileDirectory.SnapshotQualifiedUri.AbsoluteUri,
+                            directory.SnapshotQualifiedUri.AbsoluteUri,
                             string.Empty);
 
                         TransferException exception =

--- a/lib/TransferEnumerators/EnumerateDirectoryHelper.cs
+++ b/lib/TransferEnumerators/EnumerateDirectoryHelper.cs
@@ -229,7 +229,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
                     // since the OS can block access to some paths. Getting files from a location
                     // will force path discovery checks which will indicate whether or not the user
                     // is authorized to access the directory.
-                    LongPathDirectory.GetFiles(folder);
+                    foreach (var fileItem in LongPathDirectory.EnumerateFileSystemEntries(folder, "*", SearchOption.TopDirectoryOnly))
+                    {
+                        // Just try to get the first item in directly to check whether has permission to access the directory.
+                        break;
+                    }
                 }
                 catch (SecurityException)
                 {

--- a/lib/TransferEnumerators/FileEntry.cs
+++ b/lib/TransferEnumerators/FileEntry.cs
@@ -33,5 +33,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferEnumerators
             get;
             private set;
         }
+
+        public override string ToString()
+        {
+            return FullPath;
+        }
     }
 }

--- a/lib/TransferJobs/MultipleObjectsTransfer.cs
+++ b/lib/TransferJobs/MultipleObjectsTransfer.cs
@@ -386,11 +386,18 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
                     this.shouldTransferQueue.EnqueueJob(async () =>
                     {
-                        SingleObjectTransfer candidate = this.CreateTransfer(entry);
+                        try
+                        {
+                            SingleObjectTransfer candidate = this.CreateTransfer(entry);
 
-                        bool shouldTransfer = shouldTransferCallback == null || await shouldTransferCallback(candidate.Source.Instance, candidate.Destination.Instance);
+                            bool shouldTransfer = shouldTransferCallback == null || await shouldTransferCallback(candidate.Source.Instance, candidate.Destination.Instance);
 
-                        return new Tuple<SingleObjectTransfer, TransferEntry>(shouldTransfer ? candidate : null, entry);
+                            return new Tuple<SingleObjectTransfer, TransferEntry>(shouldTransfer ? candidate : null, entry);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new TransferException(TransferErrorCode.FailToEnumerateDirectory, string.Format(CultureInfo.CurrentCulture, "Error happens when handling entry {0}: {1}", entry.ToString(), ex.Message), ex);
+                        }
                     });
                 }
             }

--- a/lib/TransferJobs/StreamLocation.cs
+++ b/lib/TransferJobs/StreamLocation.cs
@@ -9,6 +9,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
     using System;
     using System.Globalization;
     using System.IO;
+    using System.Runtime.CompilerServices;
     using System.Runtime.Serialization;
 
 #if !BINARY_SERIALIZATION
@@ -16,6 +17,9 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 #endif
     internal class StreamLocation : TransferLocation
     {
+        private static ConditionalWeakTable<Stream, string> StreamIdTable = new ConditionalWeakTable<Stream, string>();
+        string streamLocationIdentity = string.Empty;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="StreamLocation"/> class.
         /// </summary>
@@ -28,6 +32,17 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
 
             this.Stream = stream;
+
+            string identity = null;
+            if (StreamIdTable.TryGetValue(stream, out identity))
+            {
+                this.streamLocationIdentity = identity;
+            }
+            else
+            {
+                this.streamLocationIdentity = Guid.NewGuid().ToString();
+                StreamIdTable.Add(stream, this.streamLocationIdentity);
+            }
         }
 
 #if !BINARY_SERIALIZATION
@@ -105,7 +120,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         //     A string that represents the transfer location.
         public override string ToString()
         {
-            return this.Stream.ToString();
+            return streamLocationIdentity;
         }
     }
 }

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -107,14 +107,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             FileLocation sourceLocation = new FileLocation(sourcePath);
             AzureBlobLocation destLocation = new AzureBlobLocation(destBlob);
+
+            // Set default request options
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 destLocation.AccessCondition = options.DestinationAccessCondition;
             }
-
-            BlobRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(destLocation) as BlobRequestOptions;
-            Debug.Assert(requestOptions != null, "Should get default BlobRequestOptions successfully.");
-            destLocation.BlobRequestOptions = requestOptions;
 
             return UploadInternalAsync(sourceLocation, destLocation, context, cancellationToken);
         }
@@ -157,14 +157,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             StreamLocation sourceLocation = new StreamLocation(sourceStream);
             AzureBlobLocation destLocation = new AzureBlobLocation(destBlob);
+
+            // Set default request options
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 destLocation.AccessCondition = options.DestinationAccessCondition;
             }
-
-            BlobRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(destLocation) as BlobRequestOptions;
-            Debug.Assert(requestOptions != null, "Should get default BlobRequestOptions successfully.");
-            destLocation.BlobRequestOptions = requestOptions;
 
             return UploadInternalAsync(sourceLocation, destLocation, context, cancellationToken);
         }
@@ -207,14 +207,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             FileLocation sourceLocation = new FileLocation(sourcePath);
             AzureFileLocation destLocation = new AzureFileLocation(destFile);
+
+            // Set default request options
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 destLocation.AccessCondition = options.DestinationAccessCondition;
             }
-
-            FileRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(destLocation) as FileRequestOptions;
-            Debug.Assert(requestOptions != null, "Should get default FileRequestOptions successfully.");
-            destLocation.FileRequestOptions = requestOptions;
 
             return UploadInternalAsync(sourceLocation, destLocation, context, cancellationToken);
         }
@@ -257,14 +257,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             StreamLocation sourceLocation = new StreamLocation(sourceStream);
             AzureFileLocation destLocation = new AzureFileLocation(destFile);
+
+            // Set default request options
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 destLocation.AccessCondition = options.DestinationAccessCondition;
             }
-
-            FileRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(destLocation) as FileRequestOptions;
-            Debug.Assert(requestOptions != null, "Should get default FileRequestOptions successfully.");
-            destLocation.FileRequestOptions = requestOptions;
 
             return UploadInternalAsync(sourceLocation, destLocation, context, cancellationToken);
         }
@@ -331,15 +331,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             DirectoryLocation sourceLocation = new DirectoryLocation(sourcePath);
             AzureBlobDirectoryLocation destLocation = new AzureBlobDirectoryLocation(destBlobDir);
             FileEnumerator sourceEnumerator = new FileEnumerator(sourceLocation, null != options? options.FollowSymlink : false);
+
+            // Set default request options
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 sourceEnumerator.SearchPattern = options.SearchPattern;
                 sourceEnumerator.Recursive = options.Recursive;
             }
-
-            BlobRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(destLocation) as BlobRequestOptions;
-            Debug.Assert(requestOptions != null, "Should get default BlobRequestOptions successfully.");
-            destLocation.BlobRequestOptions = requestOptions;
 
             return UploadDirectoryInternalAsync(sourceLocation, destLocation, sourceEnumerator, options, context, cancellationToken);
         }
@@ -382,15 +382,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             DirectoryLocation sourceLocation = new DirectoryLocation(sourcePath);
             AzureFileDirectoryLocation destLocation = new AzureFileDirectoryLocation(destFileDir);
             FileEnumerator sourceEnumerator = new FileEnumerator(sourceLocation, null == options ? false : options.FollowSymlink);
+
+            // Set default request options
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 sourceEnumerator.SearchPattern = options.SearchPattern;
                 sourceEnumerator.Recursive = options.Recursive;
             }
-
-            FileRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(destLocation) as FileRequestOptions;
-            Debug.Assert(requestOptions != null, "Should get default FileRequestOptions successfully.");
-            destLocation.FileRequestOptions = requestOptions;
 
             return UploadDirectoryInternalAsync(sourceLocation, destLocation, sourceEnumerator, options, context, cancellationToken);
         }
@@ -410,14 +410,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             AzureBlobLocation sourceLocation = new AzureBlobLocation(sourceBlob);
             FileLocation destLocation = new FileLocation(destPath);
 
+            // Set default request options
+            SetDefaultRequestOptions(sourceLocation);
+
             if (options != null)
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
-                
-                BlobRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(sourceLocation) as BlobRequestOptions;
-                Debug.Assert(requestOptions != null, "Should get default BlobRequestOptions successfully.");
-                requestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-                sourceLocation.BlobRequestOptions = requestOptions;
+
+                sourceLocation.BlobRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
             }
 
             return DownloadInternalAsync(sourceLocation, destLocation, context, cancellationToken);
@@ -462,14 +462,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             AzureBlobLocation sourceLocation = new AzureBlobLocation(sourceBlob);
             StreamLocation destLocation = new StreamLocation(destStream);
 
+            // Set default request options
+            SetDefaultRequestOptions(sourceLocation);
+
             if (options != null)
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
 
-                BlobRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(sourceLocation) as BlobRequestOptions;
-                Debug.Assert(requestOptions != null, "Should get default BlobRequestOptions successfully.");
-                requestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-                sourceLocation.BlobRequestOptions = requestOptions;
+                sourceLocation.BlobRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
             }
 
             return DownloadInternalAsync(sourceLocation, destLocation, context, cancellationToken);
@@ -514,14 +514,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             AzureFileLocation sourceLocation = new AzureFileLocation(sourceFile);
             FileLocation destLocation = new FileLocation(destPath);
 
+            // Set default request options
+            SetDefaultRequestOptions(sourceLocation);
+
             if (options != null)
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
 
-                FileRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(sourceLocation) as FileRequestOptions;
-                Debug.Assert(requestOptions != null, "Should get default FileRequestOptions successfully.");
-                requestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-                sourceLocation.FileRequestOptions = requestOptions;
+                sourceLocation.FileRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
             }
 
             return DownloadInternalAsync(sourceLocation, destLocation, context, cancellationToken);
@@ -565,15 +565,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             AzureFileLocation sourceLocation = new AzureFileLocation(sourceFile);
             StreamLocation destLocation = new StreamLocation(destStream);
+            
+            // Set default request options
+            SetDefaultRequestOptions(sourceLocation);
 
             if (options != null)
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
-                
-                FileRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(sourceLocation) as FileRequestOptions;
-                Debug.Assert(requestOptions != null, "Should get default FileRequestOptions successfully.");
-                requestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-                sourceLocation.FileRequestOptions = requestOptions;
+
+                sourceLocation.FileRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
             }
 
             return DownloadInternalAsync(sourceLocation, destLocation, context, cancellationToken);
@@ -606,16 +606,17 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             AzureBlobDirectoryLocation sourceLocation = new AzureBlobDirectoryLocation(sourceBlobDir);
             DirectoryLocation destLocation = new DirectoryLocation(destPath);
             AzureBlobEnumerator sourceEnumerator = new AzureBlobEnumerator(sourceLocation);
+            
+            // Set default request options
+            SetDefaultRequestOptions(sourceLocation);
+
             if (options != null)
             {
                 sourceEnumerator.SearchPattern = options.SearchPattern;
                 sourceEnumerator.Recursive = options.Recursive;
                 sourceEnumerator.IncludeSnapshots = options.IncludeSnapshots;
 
-                BlobRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(sourceLocation) as BlobRequestOptions;
-                Debug.Assert(requestOptions != null, "Should get default BlobRequestOptions successfully.");
-                requestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-                sourceLocation.BlobRequestOptions = requestOptions;
+                sourceLocation.BlobRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
             }
 
             return DownloadDirectoryInternalAsync(sourceLocation, destLocation, sourceEnumerator, options, context, cancellationToken);
@@ -648,17 +649,18 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             AzureFileDirectoryLocation sourceLocation = new AzureFileDirectoryLocation(sourceFileDir);
             DirectoryLocation destLocation = new DirectoryLocation(destPath);
             AzureFileEnumerator sourceEnumerator = new AzureFileEnumerator(sourceLocation);
+
+            // Set default request options
+            SetDefaultRequestOptions(sourceLocation);
+
             if (options != null)
             {
                 TransferManager.CheckSearchPatternOfAzureFileSource(options);
 
                 sourceEnumerator.SearchPattern = options.SearchPattern;
                 sourceEnumerator.Recursive = options.Recursive;
-
-                FileRequestOptions requestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(sourceLocation) as FileRequestOptions;
-                Debug.Assert(requestOptions != null, "Should get default FileRequestOptions successfully.");
-                requestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-                sourceLocation.FileRequestOptions = requestOptions;
+                
+                sourceLocation.FileRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
             }
 
             return DownloadDirectoryInternalAsync(sourceLocation, destLocation, sourceEnumerator, options, context, cancellationToken);
@@ -711,6 +713,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             AzureBlobLocation sourceLocation = new AzureBlobLocation(sourceBlob);
             AzureBlobLocation destLocation = new AzureBlobLocation(destBlob);
+
+            // Set default request options for source and destination
+            SetDefaultRequestOptions(sourceLocation);
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
@@ -767,6 +774,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             AzureBlobLocation sourceLocation = new AzureBlobLocation(sourceBlob);
             AzureFileLocation destLocation = new AzureFileLocation(destFile);
+
+            // Set default request options for source and destination
+            SetDefaultRequestOptions(sourceLocation);
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
@@ -823,6 +835,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             AzureFileLocation sourceLocation = new AzureFileLocation(sourceFile);
             AzureBlobLocation destLocation = new AzureBlobLocation(destBlob);
+
+            // Set default request options for source and destination
+            SetDefaultRequestOptions(sourceLocation);
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
@@ -880,6 +897,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             AzureFileLocation sourceLocation = new AzureFileLocation(sourceFile);
             AzureFileLocation destLocation = new AzureFileLocation(destFile);
+
+            // Set default request options for source and destination
+            SetDefaultRequestOptions(sourceLocation);
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
@@ -944,6 +966,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             UriLocation sourceLocation = new UriLocation(sourceUri);
             AzureBlobLocation destLocation = new AzureBlobLocation(destBlob);
+
+            // Set default request options for destination
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 destLocation.AccessCondition = options.DestinationAccessCondition;
@@ -1007,6 +1033,10 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 
             UriLocation sourceLocation = new UriLocation(sourceUri);
             AzureFileLocation destLocation = new AzureFileLocation(destFile);
+
+            // Set default request options for destination
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 destLocation.AccessCondition = options.DestinationAccessCondition;
@@ -1048,6 +1078,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             AzureBlobDirectoryLocation sourceLocation = new AzureBlobDirectoryLocation(sourceBlobDir);
             AzureBlobDirectoryLocation destLocation = new AzureBlobDirectoryLocation(destBlobDir);
             AzureBlobEnumerator sourceEnumerator = new AzureBlobEnumerator(sourceLocation);
+
+            // Set default request options for source and destination
+            SetDefaultRequestOptions(sourceLocation);
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 sourceEnumerator.SearchPattern = options.SearchPattern;
@@ -1091,6 +1126,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             AzureBlobDirectoryLocation sourceLocation = new AzureBlobDirectoryLocation(sourceBlobDir);
             AzureFileDirectoryLocation destLocation = new AzureFileDirectoryLocation(destFileDir);
             AzureBlobEnumerator sourceEnumerator = new AzureBlobEnumerator(sourceLocation);
+
+            // Set default request options for source and destination
+            SetDefaultRequestOptions(sourceLocation);
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 sourceEnumerator.SearchPattern = options.SearchPattern;
@@ -1134,6 +1174,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             AzureFileDirectoryLocation sourceLocation = new AzureFileDirectoryLocation(sourceFileDir);
             AzureFileDirectoryLocation destLocation = new AzureFileDirectoryLocation(destFileDir);
             AzureFileEnumerator sourceEnumerator = new AzureFileEnumerator(sourceLocation);
+
+            // Set default request options for source and destination
+            SetDefaultRequestOptions(sourceLocation);
+            SetDefaultRequestOptions(destLocation);
+
             if (options != null)
             {
                 TransferManager.CheckSearchPatternOfAzureFileSource(options);
@@ -1177,6 +1222,11 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         {
             AzureFileDirectoryLocation sourceLocation = new AzureFileDirectoryLocation(sourceFileDir);
             AzureBlobDirectoryLocation destLocation = new AzureBlobDirectoryLocation(destBlobDir);
+
+            // Set default request options for source and destination
+            SetDefaultRequestOptions(sourceLocation);
+            SetDefaultRequestOptions(destLocation);
+
             AzureFileEnumerator sourceEnumerator = new AzureFileEnumerator(sourceLocation);
             if (options != null)
             {
@@ -1401,6 +1451,40 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             {
                 AzureFileDirectoryLocation fileDirectoryLocation = location as AzureFileDirectoryLocation;
                 (targetLocation as AzureFileDirectoryLocation).UpdateCredentials(fileDirectoryLocation.FileDirectory.ServiceClient.Credentials);
+            }
+        }
+
+        private static void SetDefaultRequestOptions(TransferLocation location)
+        {
+            switch (location.Type)
+            {
+                case TransferLocationType.AzureBlob:
+                    var blobLocation = location as AzureBlobLocation;
+                    var blobRequestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(location) as BlobRequestOptions;
+                    Debug.Assert(blobRequestOptions != null, "Should get default BlobRequestOptions successfully.");
+                    blobLocation.BlobRequestOptions = blobRequestOptions;
+                    break;
+                case TransferLocationType.AzureBlobDirectory:
+                    var blobDirectoryLocation = location as AzureBlobDirectoryLocation;
+                    var blobDirectoryRequestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(location) as BlobRequestOptions;
+                    Debug.Assert(blobDirectoryRequestOptions != null, "Should get default BlobRequestOptions successfully.");
+                    blobDirectoryLocation.BlobRequestOptions = blobDirectoryRequestOptions;
+                    break;
+                case TransferLocationType.AzureFile:
+                    var fileLocation = location as AzureFileLocation;
+                    var fileRequestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(location) as FileRequestOptions;
+                    Debug.Assert(fileRequestOptions != null, "Should get default FileRequestOptions successfully.");
+                    fileLocation.FileRequestOptions = fileRequestOptions;
+                    break;
+                case TransferLocationType.AzureFileDirectory:
+                    var fileDirectoryLocation = location as AzureFileDirectoryLocation;
+                    var fileDirectoryRequestOptions = Transfer_RequestOptions.CreateDefaultRequestOptions(location) as FileRequestOptions;
+                    Debug.Assert(fileDirectoryRequestOptions != null, "Should get default FileRequestOptions successfully.");
+                    fileDirectoryLocation.FileRequestOptions = fileDirectoryRequestOptions;
+                    break;
+                default:
+                    // Do nothing for other location type
+                    break;
             }
         }
 

--- a/lib/packages.config
+++ b/lib/packages.config
@@ -6,5 +6,5 @@
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="9.3.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net45" />
 </packages>

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -106,7 +106,7 @@
     <ProjectReference Include="..\MsTestLib\MsTestLib.csproj" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -27,7 +27,7 @@
     <Compile Include="..\..\test\DMLibTest\Cases\FollowSymlinkTest.cs" Link="Cases\FollowSymlinkTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\LongFilePathTest.cs" Link="Cases\LongFilePathTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\MetadataTest.cs" Link="Cases\MetadataTest.cs" />
-    <Compile Include="..\..\test\DMLibTest\Cases\NonseekableStreamTest.cs" Link="Cases\NonseekableStreamTest.cs" />
+    <Compile Include="..\..\test\DMLibTest\Cases\StreamTest.cs" Link="Cases\StreamTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\OverwriteTest.cs" Link="Cases\OverwriteTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\ProgressHandlerTest.cs" Link="Cases\ProgressHandlerTest.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\ResumeTest.cs" Link="Cases\ResumeTest.cs" />

--- a/netcore/DMLibTest/TestClassFixtures.cs
+++ b/netcore/DMLibTest/TestClassFixtures.cs
@@ -147,15 +147,15 @@ namespace DMLibTest
         }
     }
 
-    public class NonseekableStreamTestFixture : IDisposable
+    public class StreamTestFixture : IDisposable
     {
-        public NonseekableStreamTestFixture()
+        public StreamTestFixture()
         {
-            NonseekableStreamTest.MyClassInitialize(null);
+            StreamTest.MyClassInitialize(null);
         }
         public void Dispose()
         {
-            NonseekableStreamTest.MyClassCleanup();
+            StreamTest.MyClassCleanup();
         }
     }
 

--- a/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft.WindowsAzure.Storage.DataMovement Class Library</Description>
-    <Version>0.8.1.0</Version>
+    <Version>0.9.0.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0-beta2" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
@@ -38,11 +38,11 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.8.1\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.9.0\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/samples/DataMovementSamples/DataMovementSamples/packages.config
+++ b/samples/DataMovementSamples/DataMovementSamples/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="0.8.1" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="0.9.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="9.3.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net45" />
 </packages>

--- a/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.8.1" />
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.9.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
+++ b/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
@@ -46,11 +46,11 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.8.1\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.9.0\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/samples/S3ToAzureSample/S3ToAzureSample/packages.config
+++ b/samples/S3ToAzureSample/S3ToAzureSample/packages.config
@@ -3,12 +3,12 @@
   <package id="AWSSDK.Core" version="3.1.1.0" targetFramework="net45" />
   <package id="AWSSDK.S3" version="3.1.2.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="0.8.1" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="0.9.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="9.3.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net45" />
 </packages>

--- a/test/DMLibTest/Cases/AccessConditionTest.cs
+++ b/test/DMLibTest/Cases/AccessConditionTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest.Cases
 {
     using System;

--- a/test/DMLibTest/Cases/BVT.cs
+++ b/test/DMLibTest/Cases/BVT.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest
 {
     using System;

--- a/test/DMLibTest/Cases/BigFileTest.cs
+++ b/test/DMLibTest/Cases/BigFileTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest
 {
     using System;

--- a/test/DMLibTest/Cases/BlockSizeTest.cs
+++ b/test/DMLibTest/Cases/BlockSizeTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest
 {
     using System;

--- a/test/DMLibTest/Cases/ChunkedMemoryStreamTests.cs
+++ b/test/DMLibTest/Cases/ChunkedMemoryStreamTests.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 #if DEBUG
 namespace DMLibTest.Cases
 {

--- a/test/DMLibTest/Cases/DelimiterTest.cs
+++ b/test/DMLibTest/Cases/DelimiterTest.cs
@@ -1,4 +1,10 @@
-﻿namespace DMLibTest.Cases
+﻿//------------------------------------------------------------------------------
+// <copyright file="DelimiterTest.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace DMLibTest.Cases
 {
     using DMLibTestCodeGen;
     using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/DMLibTest/Cases/FollowSymlinkTest.cs
+++ b/test/DMLibTest/Cases/FollowSymlinkTest.cs
@@ -1,4 +1,9 @@
-﻿
+﻿//------------------------------------------------------------------------------
+// <copyright file="FollowSymlinkTest.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
 
 namespace DMLibTest
 {

--- a/test/DMLibTest/Cases/LongFilePathTest.cs
+++ b/test/DMLibTest/Cases/LongFilePathTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest.Cases
 {
 

--- a/test/DMLibTest/Cases/OverwriteTest.cs
+++ b/test/DMLibTest/Cases/OverwriteTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest.Cases
 {
     using DMLibTestCodeGen;

--- a/test/DMLibTest/Cases/ProgressHandlerTest.cs
+++ b/test/DMLibTest/Cases/ProgressHandlerTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest.Cases
 {
     using DMLibTestCodeGen;

--- a/test/DMLibTest/Cases/ResumeTest.cs
+++ b/test/DMLibTest/Cases/ResumeTest.cs
@@ -138,6 +138,8 @@ namespace DMLibTest
                         Exception jobException = result.Exceptions[0];
                         Test.Info("{0}", jobException);
                         VerificationHelper.VerifyExceptionErrorMessage(jobException, "Cannot deserialize to TransferLocation when its TransferLocationType is Stream.");
+                        transferItem.DisableStreamDispose = false;
+                        transferItem.CloseStreamIfNecessary();
                         return;
                     }
                 }

--- a/test/DMLibTest/Cases/ResumeTest.cs
+++ b/test/DMLibTest/Cases/ResumeTest.cs
@@ -91,6 +91,7 @@ namespace DMLibTest
                         item.CancellationToken = tokenSource.Token;
                         item.TransferContext = transferContext;
                         transferItem = item;
+                        item.DisableStreamDispose = true;
                     };
 
                 TransferCheckpoint firstCheckpoint = null, secondCheckpoint = null;
@@ -116,6 +117,11 @@ namespace DMLibTest
                         // Cancel the transfer and store the second checkpoint
                         tokenSource.Cancel();
                     };
+
+                if ((DMLibTestContext.SourceType == DMLibDataType.Stream) || (DMLibTestContext.DestType == DMLibDataType.Stream))
+                {
+                    options.DisableDestinationFetch = true;
+                }
 
                 // Cancel and store checkpoint for resume
                 var result = this.ExecuteTestCase(sourceDataInfo, options);

--- a/test/DMLibTest/Cases/SearchPatternTest.cs
+++ b/test/DMLibTest/Cases/SearchPatternTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest
 {
     using System;

--- a/test/DMLibTest/Cases/SetAttributesTest.cs
+++ b/test/DMLibTest/Cases/SetAttributesTest.cs
@@ -1,4 +1,10 @@
-﻿namespace DMLibTest.Cases
+﻿//------------------------------------------------------------------------------
+// <copyright file="SetAttributesTest.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace DMLibTest.Cases
 {
     using System;
     using System.Collections.Generic;

--- a/test/DMLibTest/Cases/ShouldTransferTest.cs
+++ b/test/DMLibTest/Cases/ShouldTransferTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest.Cases
 {
     using DMLibTestCodeGen;

--- a/test/DMLibTest/Cases/SnapshotTest.cs
+++ b/test/DMLibTest/Cases/SnapshotTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest.Cases
 {
     using DMLibTestCodeGen;

--- a/test/DMLibTest/Cases/StreamTest.cs
+++ b/test/DMLibTest/Cases/StreamTest.cs
@@ -1,4 +1,9 @@
-﻿
+﻿//------------------------------------------------------------------------------
+// <copyright file="StreamTest.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
 namespace DMLibTest.Cases
 {
     using System;
@@ -6,11 +11,13 @@ namespace DMLibTest.Cases
     using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using DMLibTest.Util;
     using DMLibTestCodeGen;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.WindowsAzure.Storage.Blob;
+    using Microsoft.WindowsAzure.Storage.DataMovement;
     using Microsoft.WindowsAzure.Storage.File;
     using MS.Test.Common.MsTestLib;
 #if DNXCORE50
@@ -35,7 +42,7 @@ namespace DMLibTest.Cases
         }
 #else
     [TestClass]
-    public class NonseekableStreamTest : DMLibTestBase
+    public class StreamTest : DMLibTestBase
     {
 #endif
         private static readonly long[] VariedFileSize = new long[] { 0, 1, 4194304};
@@ -44,7 +51,7 @@ namespace DMLibTest.Cases
         [ClassInitialize()]
         public static void MyClassInitialize(TestContext testContext)
         {
-            Test.Info("Class Initialize: NonseekableStreamTest");
+            Test.Info("Class Initialize: StreamTest");
             DMLibTestBase.BaseClassInitialize(testContext);
             DMLibTestBase.CleanupSource = false;            
         }
@@ -66,7 +73,23 @@ namespace DMLibTest.Cases
         {
             base.BaseTestCleanup();
         }
-#endregion
+        #endregion
+
+        [TestMethod]
+        [TestCategory(Tag.Function)]
+#if DNXCORE50
+        [TestStartEnd()]
+#endif
+        public void DownloadToMultipleStreams_Positive()
+        {
+            DownloadToMultipleStreams(DMLibDataType.BlockBlob, random.Next(200, 1025) * 1024 * 1024, (random.Next(4, 101) / 4) * 4 * 1024 * 1024);
+
+            DMLibDataType[] sourceTypes = new DMLibDataType[] { DMLibDataType.BlockBlob, DMLibDataType.AppendBlob, DMLibDataType.PageBlob, DMLibDataType.CloudFile };
+            foreach (var sourceType in sourceTypes)
+            {
+                DownloadToMultipleStreams(sourceType, random.Next(10, 100) * 1024 * 1024);
+            }
+        }
 
         [TestMethod]
         [TestCategory(Tag.Function)]
@@ -309,6 +332,72 @@ namespace DMLibTest.Cases
 
             sourceAdaptor.Cleanup();
             destAdaptor.Cleanup();
+        }
+
+        private void DownloadToMultipleStreams(DMLibDataType sourceType, long fileSize, int blockSize = 0)
+        {
+            DataAdaptor<DMLibDataInfo> sourceAdaptor = GetSourceAdaptor(sourceType);
+            DataAdaptor<DMLibDataInfo> destAdaptor1 = GetDestAdaptor(DMLibDataType.Stream);
+
+            Test.Info("SourceType: {0}, filesize {1}, blocksize {2}", sourceType, fileSize, blockSize);
+
+            DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);
+            long fileSizeInByte = fileSize;
+
+            sourceDataInfo.RootNode.AddFileNode(new FileNode(FileName)
+            {
+                SizeInByte = fileSizeInByte,
+            });
+
+            sourceAdaptor.GenerateData(sourceDataInfo);
+            destAdaptor1.CreateIfNotExists();
+
+            List<TransferItem> downloadItems = new List<TransferItem>();
+
+            FileNode fileNode = sourceDataInfo.RootNode.GetFileNode(FileName);
+
+            int streamCount = random.Next(2, 6);
+            for (int i = 0; i < streamCount; ++i)
+            {
+                downloadItems.Add(new TransferItem()
+                {
+                    SourceObject = sourceAdaptor.GetTransferObject(string.Empty, fileNode),
+                    DestObject = destAdaptor1.GetTransferObject(string.Empty, new FileNode($"{FileName}_{i}") { SizeInByte = fileSizeInByte }),
+                    SourceType = sourceType,
+                    DestType = DMLibDataType.Stream,
+                    IsServiceCopy = false
+                });
+            }
+
+            var options = new TestExecutionOptions<DMLibDataInfo>()
+                {
+                    DisableDestinationFetch = true,
+                };
+
+            if (0 != blockSize)
+            {
+                options.BlockSize = blockSize;
+            }
+
+            // Execution
+            var result = this.RunTransferItems(
+                downloadItems,
+                options);
+
+            // Verify all files are transfered successfully
+            Test.Assert(result.Exceptions.Count == 0, "Verify no exception occurs.");
+
+            DMLibDataInfo destDataInfo = destAdaptor1.GetTransferDataInfo(string.Empty);
+
+            foreach (FileNode destFileNode in destDataInfo.EnumerateFileNodes())
+            {
+                var toBeValidateFileNode = destFileNode.Clone(FileName);
+                FileNode sourceFileNode = sourceDataInfo.RootNode.GetFileNode(FileName);
+                Test.Assert(DMLibDataHelper.Equals(sourceFileNode, toBeValidateFileNode), "Verify transfer result.");
+            }
+
+            sourceAdaptor.Cleanup();
+            destAdaptor1.Cleanup();
         }
     }
 }

--- a/test/DMLibTest/Cases/StreamTest.cs
+++ b/test/DMLibTest/Cases/StreamTest.cs
@@ -24,9 +24,9 @@ namespace DMLibTest.Cases
     using Xunit;
 
     [Collection(Collections.Global)]
-    public class NonseekableStreamTest : DMLibTestBase, IClassFixture<NonseekableStreamTestFixture>, IDisposable
+    public class StreamTest : DMLibTestBase, IClassFixture<StreamTestFixture>, IDisposable
     {
-        public NonseekableStreamTest()
+        public StreamTest()
         {
             MyTestInitialize();
         }
@@ -356,13 +356,14 @@ namespace DMLibTest.Cases
 
             FileNode fileNode = sourceDataInfo.RootNode.GetFileNode(FileName);
 
+
             int streamCount = random.Next(2, 6);
             for (int i = 0; i < streamCount; ++i)
             {
                 downloadItems.Add(new TransferItem()
                 {
                     SourceObject = sourceAdaptor.GetTransferObject(string.Empty, fileNode),
-                    DestObject = destAdaptor1.GetTransferObject(string.Empty, new FileNode($"{FileName}_{i}") { SizeInByte = fileSizeInByte }),
+                    DestObject = (destAdaptor1 as LocalDataAdaptor).GetTransferObject(string.Empty, $"{FileName}_{i}"),
                     SourceType = sourceType,
                     DestType = DMLibDataType.Stream,
                     IsServiceCopy = false

--- a/test/DMLibTest/Cases/UnsupportedDirectionTest.cs
+++ b/test/DMLibTest/Cases/UnsupportedDirectionTest.cs
@@ -3,6 +3,7 @@
 //    Copyright (c) Microsoft Corporation
 // </copyright>
 //------------------------------------------------------------------------------
+
 namespace DMLibTest.Cases
 {
     using System;

--- a/test/DMLibTest/DMLibTest.csproj
+++ b/test/DMLibTest/DMLibTest.csproj
@@ -61,8 +61,8 @@
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.9.3.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/test/DMLibTest/DMLibTest.csproj
+++ b/test/DMLibTest/DMLibTest.csproj
@@ -111,7 +111,7 @@
     <Compile Include="Cases\FollowSymlinkTest.cs" />
     <Compile Include="Cases\LongFilePathTest.cs" />
     <Compile Include="Cases\MetadataTest.cs" />
-    <Compile Include="Cases\NonseekableStreamTest.cs" />
+    <Compile Include="Cases\StreamTest.cs" />
     <Compile Include="Cases\OverwriteTest.cs" />
     <Compile Include="Cases\ProgressHandlerTest.cs" />
     <Compile Include="Cases\ResumeTest.cs" />

--- a/test/DMLibTest/Framework/DMLibDataInfo.cs
+++ b/test/DMLibTest/Framework/DMLibDataInfo.cs
@@ -93,9 +93,9 @@ namespace DMLibTest
                     {
                         yield return component;
                     }
-
-                    yield return this.Name;
                 }
+
+                yield return this.Name;
             }
         }
     }

--- a/test/DMLibTest/Framework/DMLibDataInfo.cs
+++ b/test/DMLibTest/Framework/DMLibDataInfo.cs
@@ -93,9 +93,10 @@ namespace DMLibTest
                     {
                         yield return component;
                     }
+                    
+                    yield return this.Name;
                 }
 
-                yield return this.Name;
             }
         }
     }

--- a/test/DMLibTest/Framework/LocalDataAdaptor.cs
+++ b/test/DMLibTest/Framework/LocalDataAdaptor.cs
@@ -49,6 +49,32 @@ namespace DMLibTest
             }
         }
 
+        public object GetTransferObject(string rootPath, string relativePath, StorageCredentials credentials = null)
+        {
+            if (credentials != null)
+            {
+                throw new NotSupportedException("Credentials is not supported in LocalDataAdaptor.");
+            }
+
+            string filePath = Path.Combine(this.BasePath, rootPath, relativePath);
+
+            if (this.useStream)
+            {
+                if (SourceOrDest.Source == this.SourceOrDest)
+                {
+                    return new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                }
+                else
+                {
+                    return new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                }
+            }
+            else
+            {
+                return filePath;
+            }
+        }
+
         public override object GetTransferObject(string rootPath, DirNode dirNode, StorageCredentials credentials = null)
         {
             if (this.useStream)

--- a/test/DMLibTest/Framework/TransferItem.cs
+++ b/test/DMLibTest/Framework/TransferItem.cs
@@ -89,6 +89,12 @@ namespace DMLibTest
             set;
         }
 
+        public bool DisableStreamDispose
+        {
+            get;
+            set;
+        }
+
         public Exception Exception
         {
             get;
@@ -97,25 +103,28 @@ namespace DMLibTest
 
         public void CloseStreamIfNecessary()
         {
-            Stream sourceStream = this.SourceObject as Stream;
-            Stream destStream = this.DestObject as Stream;
-            
-            if (sourceStream != null)
+            if (!DisableStreamDispose)
             {
-#if DNXCORE50
-                sourceStream.Dispose();
-#else
-                sourceStream.Close();
-#endif
-            }
+                Stream sourceStream = this.SourceObject as Stream;
+                Stream destStream = this.DestObject as Stream;
 
-            if (destStream != null)
-            {
+                if (sourceStream != null)
+                {
 #if DNXCORE50
-                destStream.Dispose();
+                    sourceStream.Dispose();
 #else
-                destStream.Close();
+                    sourceStream.Close();
 #endif
+                }
+
+                if (destStream != null)
+                {
+#if DNXCORE50
+                    destStream.Dispose();
+#else
+                    destStream.Close();
+#endif
+                }
             }
         }
 

--- a/test/DMLibTest/Framework/TransferItem.cs
+++ b/test/DMLibTest/Framework/TransferItem.cs
@@ -172,12 +172,6 @@ namespace DMLibTest
                 CloudFile newCloudFile = new CloudFile(cloudFile.Uri, cloudFile.ServiceClient.Credentials);
                 return newCloudFile;
             }
-            else if (locationObject is FileStream)
-            {
-                FileStream fileStream = locationObject as FileStream;
-                FileStream newFileStream = new FileStream(fileStream.Name, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
-                return newFileStream;
-            }
             else
             {
                 return locationObject;

--- a/test/DMLibTest/packages.config
+++ b/test/DMLibTest/packages.config
@@ -7,5 +7,5 @@
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="9.3.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net45" />
 </packages>

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.8.2.0")]
-[assembly: AssemblyFileVersion("0.8.2.0")]
+[assembly: AssemblyVersion("0.9.0.0")]
+[assembly: AssemblyFileVersion("0.9.0.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.8.1.0")]
-[assembly: AssemblyFileVersion("0.8.1.0")]
+[assembly: AssemblyVersion("0.8.2.0")]
+[assembly: AssemblyFileVersion("0.8.2.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>0.8.2</version>
+    <version>0.9.0</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -19,12 +19,12 @@
     <dependencies>
       <group targetFramework="net45">
         <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" />
-        <dependency id="WindowsAzure.Storage" version="9.3.0" />
+        <dependency id="WindowsAzure.Storage" version="9.3.2" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Mono.Posix.NETStandard" version="1.0.0-beta2" />
         <dependency id="NETStandard.Library" version="2.0.1" />
-        <dependency id="WindowsAzure.Storage" version="9.3.0" />
+        <dependency id="WindowsAzure.Storage" version="9.3.2" />
         <dependency id="System.Runtime.Serialization.Xml" version="4.3.0" />
         <dependency id="System.Threading.ThreadPool" version="4.3.0" />
       </group>

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
1. Add more detailed error message when got exception during enumeration.
2. Disable transactional MD5 in sync copying when using https protocol
3. Add support to download from one Azure Blob/File to multiple stream instances.
4. Upgrade to XSCL 9.3.0