### PR TITLE
Upgrade to Azure Storage Client Library 9.4.2 and fix bugs

### DIFF
--- a/BreakingChanges.txt
+++ b/BreakingChanges.txt
@@ -1,3 +1,9 @@
+Tracking Breaking Changes since 0.9.0
+
+   - Changed dependency from azure storage client library 9.3.2 to azure storage blob client library 9.4.2 and azure storage file client library 9.4.2
+     To upgrade to DataMovement Library 0.10.0 from previous version, please uninstall azure storage client library package first to avoid compiling error
+   - For DataMovement Library on .Net Framework, the minimum required .Net Framework version changed from 4.5 to 4.5.2
+
 Tracking Breaking Changes since 0.8.1
 
    - Change to overwrite destination's metadata with source's metadata in async copying instead of keeping destination's metadata

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Microsoft Azure Storage Data Movement Library (0.10.0)
+# Microsoft Azure Storage Data Movement Library (0.10.1)
 
 The Microsoft Azure Storage Data Movement Library designed for high-performance uploading, downloading and copying Azure Storage Blob and File. This library is based on the core data movement framework that powers [AzCopy](https://azure.microsoft.com/documentation/articles/storage-use-azcopy/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Microsoft Azure Storage Data Movement Library (0.9.0)
+# Microsoft Azure Storage Data Movement Library (0.10.0)
 
 The Microsoft Azure Storage Data Movement Library designed for high-performance uploading, downloading and copying Azure Storage Blob and File. This library is based on the core data movement framework that powers [AzCopy](https://azure.microsoft.com/documentation/articles/storage-use-azcopy/).
 
@@ -30,7 +30,7 @@ For the best development experience, we recommend that developers use the offici
 
 ## Target Frameworks
 
-- .NET Framework 4.5 or above
+- .NET Framework 4.5.2 or above
 - Netstandard2.0
 
 ## Requirements
@@ -60,12 +60,17 @@ within your project you can also have them installed by the .NET package manager
 
 ## Dependencies
 
-### Azure Storage Client Library
+### Azure Storage Blob Client Library
 
-This version depends on Azure Storage Client Library
+This version depends on Azure Storage Blob Client Library
 
-- [WindowsAzure.Storage](https://www.nuget.org/packages/WindowsAzure.Storage/)
+- [Microsoft.Azure.Storage.Blob](https://www.nuget.org/packages/Microsoft.Azure.Storage.Blob/)
 
+### Azure Storage File Client Library
+
+This version depends on Azure Storage File Client Library
+
+- [Microsoft.Azure.Storage.File](https://www.nuget.org/packages/Microsoft.Azure.Storage.File/)
 
 
 ## Code Samples

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Once you setup the storage blob context, you can start to use `WindowsAzure.Stor
 ```csharp
 // Setup the number of the concurrent operations
 TransferManager.Configurations.ParallelOperations = 64;
-// Setup the transfer context and track the upoload progress
+// Setup the transfer context and track the upload progress
 SingleTransferContext context = new SingleTransferContext();
 context.ProgressHandler = new Progress<TransferStatus>((progress) =>
 {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-2019.02.18 Version 0.10.0
+2019.02.18 Version 0.10.1
  * All Services on both .Net Framework and .Net Core
    - Changed dependency from azure storage client library 9.3.2 to azure storage blob client library 9.4.2 and azure storage file client library 9.4.2
    - Fixed issue of config to disable content MD5 checking in download doesn't take effect during resuming

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,13 @@
+2019.02.18 Version 0.10.0
+ * All Services on both .Net Framework and .Net Core
+   - Changed dependency from azure storage client library 9.3.2 to azure storage blob client library 9.4.2 and azure storage file client library 9.4.2
+   - Fixed issue of config to disable content MD5 checking in download doesn't take effect during resuming
+   - Fixed issue of hang when uploading from a non-fixed sized stream
+ * Blob Service on both .Net Framework and .Net Core
+   - Fixed issue of block id may not be correct when changing BlockSize during uploading from a non-fixed sized stream to block blob
+ * All Services on .Net Framework
+   - Minimum required .Net Framework version is changed from 4.5 to 4.5.2
+
 2018.10.25 Version 0.9.0
  * All Services on both .Net Framework and .Net Core
    - Upgrade azure storage client library to 9.3.2

--- a/lib/DataMovement.csproj
+++ b/lib/DataMovement.csproj
@@ -9,11 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.WindowsAzure.Storage.DataMovement</RootNamespace>
     <AssemblyName>Microsoft.WindowsAzure.Storage.DataMovement</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
-    <DefineConstants>CODE_ACCESS_SECURITY;BINARY_SERIALIZATION;REQUEST_EVENT_ARGS_EXPOSES_REQUEST;$(DefineConstants)</DefineConstants>
+    <DefineConstants>CODE_ACCESS_SECURITY;BINARY_SERIALIZATION;$(DefineConstants)</DefineConstants>
     <RestorePackages>true</RestorePackages>
     <WINDOWSDESKTOP />
   </PropertyGroup>
@@ -54,12 +54,17 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Blob, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.9.4.2\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Common, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Common.9.4.2\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.File.9.4.2\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -69,6 +74,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="WindowsBase" />
@@ -79,6 +85,7 @@
     </Compile>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="ChunkedMemoryStream.cs" />
+    <Compile Include="Extensions\StorageCopyState.cs" />
     <Compile Include="FileNativeMethods.cs" />
     <Compile Include="LongPathFile.cs" />
     <Compile Include="LongPathFileStream.cs" />
@@ -210,7 +217,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/lib/Extensions/StorageCopyState.cs
+++ b/lib/Extensions/StorageCopyState.cs
@@ -1,0 +1,146 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="StorageCopyState.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.WindowsAzure.Storage.DataMovement.Extensions
+{
+    using System;
+
+    internal enum StorageCopyStatus
+    {
+        //
+        // Summary:
+        //     The copy status is invalid.
+        Invalid = 0,
+        //
+        // Summary:
+        //     The copy operation is pending.
+        Pending = 1,
+        //
+        // Summary:
+        //     The copy operation succeeded.
+        Success = 2,
+        //
+        // Summary:
+        //     The copy operation has been aborted.
+        Aborted = 3,
+        //
+        // Summary:
+        //     The copy operation encountered an error.
+        Failed = 4
+    }
+
+    internal class StorageCopyState
+    {
+        public StorageCopyState(Microsoft.WindowsAzure.Storage.Blob.CopyState blobCopyState)
+        {
+            this.CopyId = blobCopyState.CopyId;
+            this.CompletionTime = blobCopyState.CompletionTime;
+            this.SetStatus(blobCopyState.Status);
+            this.Source = blobCopyState.Source;
+            this.BytesCopied = blobCopyState.BytesCopied;
+            this.TotalBytes = blobCopyState.TotalBytes;
+            this.StatusDescription = blobCopyState.StatusDescription;
+            this.DestinationSnapshotTime = blobCopyState.DestinationSnapshotTime;
+        }
+
+        public StorageCopyState(Microsoft.WindowsAzure.Storage.File.CopyState fileCopyState)
+        {
+            this.CopyId = fileCopyState.CopyId;
+            this.CompletionTime = fileCopyState.CompletionTime;
+            this.SetStatus(fileCopyState.Status);
+            this.Source = fileCopyState.Source;
+            this.BytesCopied = fileCopyState.BytesCopied;
+            this.TotalBytes = fileCopyState.TotalBytes;
+            this.StatusDescription = fileCopyState.StatusDescription;
+            this.DestinationSnapshotTime = fileCopyState.DestinationSnapshotTime;
+        }
+
+        private void SetStatus(Microsoft.WindowsAzure.Storage.Blob.CopyStatus blobCopyStatus)
+        {
+            switch (blobCopyStatus)
+            {
+                case Blob.CopyStatus.Invalid:
+                    this.Status = StorageCopyStatus.Invalid;
+                    break;
+                case Blob.CopyStatus.Pending:
+                    this.Status = StorageCopyStatus.Pending;
+                    break;
+                case Blob.CopyStatus.Success:
+                    this.Status = StorageCopyStatus.Success;
+                    break;
+                case Blob.CopyStatus.Aborted:
+                    this.Status = StorageCopyStatus.Aborted;
+                    break;
+                case Blob.CopyStatus.Failed:
+                    this.Status = StorageCopyStatus.Failed;
+                    break;
+                default:
+                    this.Status = StorageCopyStatus.Invalid;
+                    break;
+            }
+        }
+
+        private void SetStatus(Microsoft.WindowsAzure.Storage.File.CopyStatus fileCopyStatus)
+        {
+            switch (fileCopyStatus)
+            {
+                case File.CopyStatus.Invalid:
+                    this.Status = StorageCopyStatus.Invalid;
+                    break;
+                case File.CopyStatus.Pending:
+                    this.Status = StorageCopyStatus.Pending;
+                    break;
+                case File.CopyStatus.Success:
+                    this.Status = StorageCopyStatus.Success;
+                    break;
+                case File.CopyStatus.Aborted:
+                    this.Status = StorageCopyStatus.Aborted;
+                    break;
+                case File.CopyStatus.Failed:
+                    this.Status = StorageCopyStatus.Failed;
+                    break;
+                default:
+                    this.Status = StorageCopyStatus.Invalid;
+                    break;
+            }
+        }
+
+        //
+        // Summary:
+        //     Gets the ID of the copy operation.
+        public string CopyId { get; private set; }
+        //
+        // Summary:
+        //     Gets the time the copy operation completed, and indicates whether completion
+        //     was due to a successful copy, the cancelling of the operation, or a failure.
+        public DateTimeOffset? CompletionTime { get; private set; }
+        //
+        // Summary:
+        //     Gets the status of the copy operation.
+        public StorageCopyStatus Status { get; private set; }
+        //
+        // Summary:
+        //     Gets the source URI of a copy operation.
+        public Uri Source { get; private set; }
+        //
+        // Summary:
+        //     Gets the number of bytes copied in the operation so far.
+        public long? BytesCopied { get; private set; }
+        //
+        // Summary:
+        //     Gets the total number of bytes in the source of the copy.
+        public long? TotalBytes { get; private set; }
+        //
+        // Summary:
+        //     Gets the description of the current status, if any.
+        public string StatusDescription { get; private set; }
+        //
+        // Summary:
+        //     Gets the incremental destination snapshot time for the latest incremental copy,
+        //     if present.
+        public DateTimeOffset? DestinationSnapshotTime { get; private set; }
+    }
+}

--- a/lib/Extensions/StorageCopyState.cs
+++ b/lib/Extensions/StorageCopyState.cs
@@ -37,25 +37,21 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.Extensions
         public StorageCopyState(Microsoft.WindowsAzure.Storage.Blob.CopyState blobCopyState)
         {
             this.CopyId = blobCopyState.CopyId;
-            this.CompletionTime = blobCopyState.CompletionTime;
             this.SetStatus(blobCopyState.Status);
             this.Source = blobCopyState.Source;
             this.BytesCopied = blobCopyState.BytesCopied;
             this.TotalBytes = blobCopyState.TotalBytes;
             this.StatusDescription = blobCopyState.StatusDescription;
-            this.DestinationSnapshotTime = blobCopyState.DestinationSnapshotTime;
         }
 
         public StorageCopyState(Microsoft.WindowsAzure.Storage.File.CopyState fileCopyState)
         {
             this.CopyId = fileCopyState.CopyId;
-            this.CompletionTime = fileCopyState.CompletionTime;
             this.SetStatus(fileCopyState.Status);
             this.Source = fileCopyState.Source;
             this.BytesCopied = fileCopyState.BytesCopied;
             this.TotalBytes = fileCopyState.TotalBytes;
             this.StatusDescription = fileCopyState.StatusDescription;
-            this.DestinationSnapshotTime = fileCopyState.DestinationSnapshotTime;
         }
 
         private void SetStatus(Microsoft.WindowsAzure.Storage.Blob.CopyStatus blobCopyStatus)
@@ -114,11 +110,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.Extensions
         public string CopyId { get; private set; }
         //
         // Summary:
-        //     Gets the time the copy operation completed, and indicates whether completion
-        //     was due to a successful copy, the cancelling of the operation, or a failure.
-        public DateTimeOffset? CompletionTime { get; private set; }
-        //
-        // Summary:
         //     Gets the status of the copy operation.
         public StorageCopyStatus Status { get; private set; }
         //
@@ -137,10 +128,5 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.Extensions
         // Summary:
         //     Gets the description of the current status, if any.
         public string StatusDescription { get; private set; }
-        //
-        // Summary:
-        //     Gets the incremental destination snapshot time for the latest incremental copy,
-        //     if present.
-        public DateTimeOffset? DestinationSnapshotTime { get; private set; }
     }
 }

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/lib/TransferControllers/AsyncCopyControllers/AsyncCopyController.cs
+++ b/lib/TransferControllers/AsyncCopyControllers/AsyncCopyController.cs
@@ -14,6 +14,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
     using System.Threading.Tasks;
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.Blob.Protocol;
+    using Microsoft.WindowsAzure.Storage.DataMovement.Extensions;
     using Microsoft.WindowsAzure.Storage.File;
 
     internal abstract class AsyncCopyController : TransferControllerBase
@@ -497,7 +498,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                 if (null != se.RequestInformation
                 && BlobErrorCodeStrings.PendingCopyOperation == se.RequestInformation.ErrorCode)
                 {
-                    CopyState copyState = this.FetchCopyStateAsync().Result;
+                    StorageCopyState copyState = this.FetchCopyStateAsync().Result;
 
                     if (null == copyState)
                     {
@@ -564,7 +565,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             this.hasWork = false;
             this.StartCallbackHandler();
 
-            CopyState copyState = null;
+            StorageCopyState copyState = null;
 
             try
             {
@@ -593,7 +594,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             await this.HandleFetchCopyStateResultAsync(copyState);
         }
 
-        private async Task HandleFetchCopyStateResultAsync(CopyState copyState)
+        private async Task HandleFetchCopyStateResultAsync(StorageCopyState copyState)
         {
             if (null == copyState)
             {
@@ -617,7 +618,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                             Resources.MismatchFoundBetweenLocalAndServerCopyIdsException);
                 }
 
-                if (CopyStatus.Success == copyState.Status)
+                if (StorageCopyStatus.Success == copyState.Status)
                 {
                     this.UpdateTransferProgress(copyState);
 
@@ -632,7 +633,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
 
                     this.SetFinished();
                 }
-                else if (CopyStatus.Pending == copyState.Status)
+                else if (StorageCopyStatus.Pending == copyState.Status)
                 {
                     this.UpdateTransferProgress(copyState);
 
@@ -657,7 +658,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             }
         }
 
-        private void UpdateTransferProgress(CopyState copyState)
+        private void UpdateTransferProgress(StorageCopyState copyState)
         {
             if (null != copyState &&
                 copyState.TotalBytes.HasValue)
@@ -782,7 +783,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
         protected abstract Task DoFetchDestAttributesAsync();
         protected abstract Task<string> DoStartCopyAsync();
         protected abstract void DoHandleGetDestinationException(StorageException se);
-        protected abstract Task<CopyState> FetchCopyStateAsync();
+        protected abstract Task<StorageCopyState> FetchCopyStateAsync();
         protected abstract Task SetAttributesAsync(SetAttributesCallbackAsync setAttributes);
     }
 }

--- a/lib/TransferControllers/AsyncCopyControllers/BlobAsyncCopyController.cs
+++ b/lib/TransferControllers/AsyncCopyControllers/BlobAsyncCopyController.cs
@@ -14,6 +14,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.DataMovement;
+    using Microsoft.WindowsAzure.Storage.DataMovement.Extensions;
 
     /// <summary>
     /// Blob asynchronous copy.
@@ -121,7 +122,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                 if (BlobType.BlockBlob == this.destBlob.BlobType)
                 {
                     return (this.destBlob as CloudBlockBlob).StartCopyAsync(
-                             this.SourceFile.GenerateCopySourceFile(),
+                             this.SourceFile.GenerateCopySourceUri(),
                              null,
                              destAccessCondition,
                              Utils.GenerateBlobRequestOptions(this.destLocation.BlobRequestOptions),
@@ -168,7 +169,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             }
         }
 
-        protected override async Task<CopyState> FetchCopyStateAsync()
+        protected override async Task<StorageCopyState> FetchCopyStateAsync()
         {
             await this.destBlob.FetchAttributesAsync(
                 Utils.GenerateConditionWithCustomerCondition(this.destLocation.AccessCondition),
@@ -176,7 +177,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                 Utils.GenerateOperationContext(this.TransferContext),
                 this.CancellationToken);
 
-            return this.destBlob.CopyState;
+            return new StorageCopyState(this.destBlob.CopyState);
         }
 
         protected override async Task SetAttributesAsync(SetAttributesCallbackAsync setCustomAttributes)

--- a/lib/TransferControllers/AsyncCopyControllers/FileAsyncCopyController.cs
+++ b/lib/TransferControllers/AsyncCopyControllers/FileAsyncCopyController.cs
@@ -13,6 +13,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.DataMovement;
+    using Microsoft.WindowsAzure.Storage.DataMovement.Extensions;
     using Microsoft.WindowsAzure.Storage.File;
 
     /// <summary>
@@ -118,7 +119,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
         {
         }
 
-        protected override async Task<CopyState> FetchCopyStateAsync()
+        protected override async Task<StorageCopyState> FetchCopyStateAsync()
         {
             await this.destFile.FetchAttributesAsync(
                 Utils.GenerateConditionWithCustomerCondition(this.destLocation.AccessCondition),
@@ -126,7 +127,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                 Utils.GenerateOperationContext(this.TransferContext),
                 this.CancellationToken);
 
-            return this.destFile.CopyState;
+            return new StorageCopyState(this.destFile.CopyState);
         }
 
         protected override async Task SetAttributesAsync(SetAttributesCallbackAsync setCustomAttributes)

--- a/lib/TransferControllers/TransferReaders/StreamedReader.cs
+++ b/lib/TransferControllers/TransferReaders/StreamedReader.cs
@@ -488,7 +488,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
                     // Should only get into this block once.
                     if (-1 == this.SharedTransferData.TotalLength)
                     {
-                        this.SharedTransferData.TotalLength = this.readLength;
+                        this.SharedTransferData.UpdateTotalLength(this.readLength);
                     }
 
                     this.state = State.Finished;

--- a/lib/TransferControllers/TransferReaders/StreamedReader.cs
+++ b/lib/TransferControllers/TransferReaders/StreamedReader.cs
@@ -449,6 +449,12 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             if ((currentReadLength == this.SharedTransferData.TotalLength) || endofStream)
             {
                 Interlocked.Exchange(ref this.readCompleted, 1);
+
+                // Should only get into this block once.
+                if (-1 == this.SharedTransferData.TotalLength)
+                {
+                    this.SharedTransferData.UpdateTotalLength(this.readLength);
+                }
             }
 
             if (endofStream && (-1 != this.SharedTransferData.TotalLength) && (currentReadLength != this.SharedTransferData.TotalLength))
@@ -485,12 +491,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement.TransferControllers
             {
                 if (0 == Interlocked.Exchange(ref this.setCompletionDone, 1))
                 {
-                    // Should only get into this block once.
-                    if (-1 == this.SharedTransferData.TotalLength)
-                    {
-                        this.SharedTransferData.UpdateTotalLength(this.readLength);
-                    }
-
                     this.state = State.Finished;
                     if (!this.md5HashStream.SucceededSeparateMd5Calculator)
                     {

--- a/lib/TransferJobs/AzureBlobDirectoryLocation.cs
+++ b/lib/TransferJobs/AzureBlobDirectoryLocation.cs
@@ -18,17 +18,24 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 #else
     [DataContract]
 #endif // BINARY_SERIALIZATION
+    [KnownType(typeof(SerializableBlobRequestOptions))]
     internal class AzureBlobDirectoryLocation : TransferLocation
 #if BINARY_SERIALIZATION
         , ISerializable
 #endif // BINARY_SERIALIZATION
     {
         private const string BlobDirName = "CloudBlobDir";
+        private const string RequestOptionsName = "RequestOptions";
 
 #if !BINARY_SERIALIZATION
         [DataMember]
 #endif
         private SerializableCloudBlobDirectory blobDirectorySerializer;
+
+#if !BINARY_SERIALIZATION
+        [DataMember]
+#endif
+        private SerializableRequestOptions requestOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureBlobDirectoryLocation"/> class.
@@ -54,6 +61,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
 
             this.blobDirectorySerializer = (SerializableCloudBlobDirectory)info.GetValue(BlobDirName, typeof(SerializableCloudBlobDirectory));
+            this.requestOptions = (SerializableBlobRequestOptions)info.GetValue(RequestOptionsName, typeof(SerializableBlobRequestOptions));
         }
 #endif // BINARY_SERIALIZATION
 
@@ -95,8 +103,14 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// </summary>
         internal BlobRequestOptions BlobRequestOptions
         {
-            get;
-            set;
+            get
+            {
+                return (BlobRequestOptions)SerializableBlobRequestOptions.GetRequestOptions(this.requestOptions);
+            }
+            set
+            {
+                SerializableRequestOptions.SetRequestOptions(ref this.requestOptions, value);
+            }
         }
 
 #if BINARY_SERIALIZATION
@@ -113,6 +127,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
 
             info.AddValue(BlobDirName, this.blobDirectorySerializer, typeof(SerializableCloudBlobDirectory));
+            info.AddValue(RequestOptionsName, this.requestOptions, typeof(SerializableBlobRequestOptions));
         }
 #endif // BINARY_SERIALIZATION
 

--- a/lib/TransferJobs/AzureFileDirectoryLocation.cs
+++ b/lib/TransferJobs/AzureFileDirectoryLocation.cs
@@ -18,17 +18,24 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
 #else
     [DataContract]
 #endif // BINARY_SERIALIZATION
+    [KnownType(typeof(SerializableFileRequestOptions))]
     internal class AzureFileDirectoryLocation : TransferLocation
 #if BINARY_SERIALIZATION
         , ISerializable
 #endif // BINARY_SERIALIZATION
     {
         private const string FileDirName = "FileDir";
-        
+        private const string RequestOptionsName = "RequestOptions";
+
 #if !BINARY_SERIALIZATION
         [DataMember]
 #endif
         private SerializableCloudFileDirectory fileDirectorySerializer;
+
+#if !BINARY_SERIALIZATION
+        [DataMember]
+#endif
+        private SerializableRequestOptions requestOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureFileDirectoryLocation"/> class.
@@ -54,6 +61,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
 
             this.fileDirectorySerializer = (SerializableCloudFileDirectory)info.GetValue(FileDirName, typeof(SerializableCloudFileDirectory));
+            this.requestOptions = (SerializableRequestOptions)info.GetValue(RequestOptionsName, typeof(SerializableRequestOptions));
         }
 #endif // BINARY_SERIALIZATION
 
@@ -95,8 +103,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// </summary>
         internal FileRequestOptions FileRequestOptions
         {
-            get;
-            set;
+            get
+            {
+                return (FileRequestOptions)SerializableRequestOptions.GetRequestOptions(this.requestOptions);
+            }
+
+            set
+            {
+                SerializableRequestOptions.SetRequestOptions(ref this.requestOptions, value);
+            }
         }
 
 #if BINARY_SERIALIZATION
@@ -113,6 +128,7 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
 
             info.AddValue(FileDirName, this.fileDirectorySerializer, typeof(SerializableCloudFileDirectory));
+            info.AddValue(RequestOptionsName, this.requestOptions, typeof(SerializableRequestOptions));
         }
 #endif // BINARY_SERIALIZATION
 

--- a/lib/TransferJobs/AzureFileLocation.cs
+++ b/lib/TransferJobs/AzureFileLocation.cs
@@ -30,13 +30,19 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         private const string RequestOptionsName = "RequestOptions";
         private const string ETagName = "ETag";
 
+#if !BINARY_SERIALIZATION
         [DataMember]
+#endif
         private SerializableAccessCondition accessCondition;
 
+#if !BINARY_SERIALIZATION
         [DataMember]
+#endif
         private SerializableRequestOptions requestOptions;
 
+#if !BINARY_SERIALIZATION
         [DataMember]
+#endif
         private SerializableCloudFile fileSerializer;
 
         

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -37,27 +37,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
         /// </summary>
         private static ConcurrentDictionary<TransferKey, Transfer> allTransfers = new ConcurrentDictionary<TransferKey, Transfer>();
 
-#if REQUEST_EVENT_ARGS_EXPOSES_REQUEST // DNX profiles don't expose the HttpWebRequest through RequestEventArgs, so the user agent cannot be set
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline", Justification = "Performance")]
-        static TransferManager()
-        {
-            OperationContext.GlobalSendingRequest += (sender, args) =>
-            {
-                // User agent string format: [UserAgentPrefix] <DMLib product token> <XSCL product token>
-                // e.g. Suppose UserAgentPrefix is "MyApp", the overall user agent string would be like
-                // 'MyApp DataMovement/0.5.0.0 WA-Storage/8.0.0 (.NET CLR 4.0.30319.34014; Win32NT 6.2.9200.0)' 
-                string userAgent = Constants.UserAgent + " " + Microsoft.WindowsAzure.Storage.Shared.Protocol.Constants.HeaderConstants.UserAgent;
-
-                if (!string.IsNullOrEmpty(configurations.UserAgentPrefix))
-                {
-                    userAgent = configurations.UserAgentPrefix + " " + userAgent;
-                }
-                
-                args.Request.UserAgent = userAgent;
-            };
-        }
-#endif // REQUEST_EVENT_ARGS_EXPOSES_REQUEST
-
         /// <summary>
         /// Gets or sets the transfer configurations associated with the transfer manager
         /// </summary>

--- a/lib/TransferStatusHelpers/SharedTransferData.cs
+++ b/lib/TransferStatusHelpers/SharedTransferData.cs
@@ -27,6 +27,15 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
         }
 
+        /// <summary>
+        /// Update totallength but don't update BlockSize accordingly.
+        /// </summary>
+        /// <param name="value"></param>
+        public void UpdateTotalLength(long value)
+        {
+            this.totalLength = value;
+        }
+
         public int BlockSize { get; set; }
 
         public int MemoryChunksRequiredEachTime { get; set; }

--- a/lib/Transfer_RequestOptions.cs
+++ b/lib/Transfer_RequestOptions.cs
@@ -12,7 +12,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.File;
     using Microsoft.WindowsAzure.Storage.RetryPolicies;
-    using Microsoft.WindowsAzure.Storage.Table;
 
     /// <summary>
     /// Defines default RequestOptions for every type of transfer job.
@@ -172,30 +171,6 @@ namespace Microsoft.WindowsAzure.Storage.DataMovement
             }
 
             return requestOptions;
-        }
-
-        /// <summary>
-        /// Gets the default <see cref="TableRequestOptions"/>.
-        /// </summary>
-        /// <value>The default <see cref="TableRequestOptions"/></value>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "It will be called in TableDataMovement project.")]
-        public static TableRequestOptions DefaultTableRequestOptions
-        {
-            get
-            {
-                IRetryPolicy defaultRetryPolicy = new TransferRetryPolicy(
-                    retryPoliciesDefaultBackoff,
-                    DefaultRetryCountXMsError,
-                    DefaultRetryCountOtherError);
-
-                return new TableRequestOptions
-                {
-                    MaximumExecutionTime = DefaultMaximumExecutionTime,
-                    RetryPolicy = defaultRetryPolicy,
-                    ServerTimeout = DefaultServerTimeout,
-                    PayloadFormat = TablePayloadFormat.Json
-                };
-            }
         }
 
         /// <summary>

--- a/lib/packages.config
+++ b/lib/packages.config
@@ -1,10 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.Blob" version="9.4.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="9.4.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.File" version="9.4.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net45" />
 </packages>

--- a/netcore/DMLibTest/CloudBlobContainerExtensions.cs
+++ b/netcore/DMLibTest/CloudBlobContainerExtensions.cs
@@ -8,7 +8,7 @@ namespace DMLibTest
     {
         public static void Create(this CloudBlobContainer container, BlobRequestOptions requestOptions = null, OperationContext operationContext = null)
         {
-            container.CreateAsync(requestOptions, operationContext).GetAwaiter().GetResult();
+            container.CreateAsync(BlobContainerPublicAccessType.Off, requestOptions, operationContext).GetAwaiter().GetResult();
         }
 
         public static bool CreateIfNotExists(this CloudBlobContainer container, BlobRequestOptions requestOptions = null, OperationContext operationContext = null)

--- a/netcore/DMLibTest/Constants.cs
+++ b/netcore/DMLibTest/Constants.cs
@@ -1,7 +1,24 @@
-﻿namespace DMLibTest
+﻿using System;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace DMLibTest
 {
     internal static class Collections
     {
         public const string Global = "global";
+    }
+
+    internal static class RequestOptions
+    {
+        public static BlobRequestOptions DefaultBlobRequestOptions
+        {
+            get
+            {
+                return new BlobRequestOptions()
+                {
+                    MaximumExecutionTime = TimeSpan.FromMinutes(15)
+                };
+            }
+        }
     }
 }

--- a/netcore/DMLibTest/Constants.cs
+++ b/netcore/DMLibTest/Constants.cs
@@ -7,18 +7,4 @@ namespace DMLibTest
     {
         public const string Global = "global";
     }
-
-    internal static class RequestOptions
-    {
-        public static BlobRequestOptions DefaultBlobRequestOptions
-        {
-            get
-            {
-                return new BlobRequestOptions()
-                {
-                    MaximumExecutionTime = TimeSpan.FromMinutes(15)
-                };
-            }
-        }
-    }
 }

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -95,6 +95,9 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
+    <PackageReference Include="Microsoft.Azure.Storage.File" Version="9.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
@@ -106,7 +109,6 @@
     <ProjectReference Include="..\MsTestLib\MsTestLib.csproj" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft.WindowsAzure.Storage.DataMovement Class Library</Description>
-    <Version>0.10.0.0</Version>
+    <Version>0.10.1.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft.WindowsAzure.Storage.DataMovement Class Library</Description>
-    <Version>0.9.1.0</Version>
+    <Version>0.10.0.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
@@ -35,10 +35,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
+    <PackageReference Include="Microsoft.Azure.Storage.File" Version="9.4.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0-beta2" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.2" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.WindowsAzure.Storage.DataMovement/Microsoft.WindowsAzure.Storage.DataMovement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft.WindowsAzure.Storage.DataMovement Class Library</Description>
-    <Version>0.9.0.0</Version>
+    <Version>0.9.1.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/DataMovementSamples/DataMovementSamples/App.config
+++ b/samples/DataMovementSamples/DataMovementSamples/App.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
     <!-- We assume you will use the Azure SDK Storage Emulator by default. If you have an Azure Subscription you can alternatively 
          create a Storage Account and run against the Storage service by using the second connection string below and insert 
          your storage account name and key. -->
-    <add key="StorageConnectionString" value="UseDevelopmentStorage=true;" />
+    <add key="StorageConnectionString" value="UseDevelopmentStorage=true;"/>
     <!--add key="StorageConnectionString" value="DefaultEndpointsProtocol=https;AccountName=[AccountName];AccountKey=[AccountKey]" />-->
   </appSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
@@ -48,8 +48,8 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.10.0\lib\net452\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.10.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.10.1\lib\net452\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DataMovementSamples</RootNamespace>
     <AssemblyName>DataMovementSamples</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,14 +36,20 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Blob, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.9.4.2\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Common, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Common.9.4.2\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.File.9.4.2\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.9.0\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.10.0\lib\net452\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/samples/DataMovementSamples/DataMovementSamples/packages.config
+++ b/samples/DataMovementSamples/DataMovementSamples/packages.config
@@ -1,12 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="0.9.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.Blob" version="9.4.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="9.4.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="0.10.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.File" version="9.4.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net45" />
 </packages>

--- a/samples/DataMovementSamples/DataMovementSamples/packages.config
+++ b/samples/DataMovementSamples/DataMovementSamples/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Storage.Blob" version="9.4.2" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.Common" version="9.4.2" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="0.10.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="0.10.1" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.File" version="9.4.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />

--- a/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.10.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.10.1" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
@@ -24,7 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.9.0" />
+    <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="0.10.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/S3ToAzureSample/S3ToAzureSample/App.config
+++ b/samples/S3ToAzureSample/S3ToAzureSample/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
   </startup>
   <appSettings>
     <!-- Please uncomment the following settings and insert your Amazon S3 and Microsoft Azure account information -->

--- a/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
+++ b/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>S3ToAzureSample</RootNamespace>
     <AssemblyName>S3ToAzureSample</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -43,17 +44,20 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Blob, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.9.4.2\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Common, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Common.9.4.2\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.File.9.4.2\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.9.0\lib\net45\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.10.0\lib\net452\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -70,7 +74,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
+++ b/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
@@ -56,8 +56,8 @@
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.10.0\lib\net452\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage.DataMovement, Version=0.10.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.0.10.1\lib\net452\Microsoft.WindowsAzure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/samples/S3ToAzureSample/S3ToAzureSample/packages.config
+++ b/samples/S3ToAzureSample/S3ToAzureSample/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Storage.Blob" version="9.4.2" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.Common" version="9.4.2" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="0.10.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="0.10.1" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.File" version="9.4.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />

--- a/samples/S3ToAzureSample/S3ToAzureSample/packages.config
+++ b/samples/S3ToAzureSample/S3ToAzureSample/packages.config
@@ -3,12 +3,14 @@
   <package id="AWSSDK.Core" version="3.1.1.0" targetFramework="net45" />
   <package id="AWSSDK.S3" version="3.1.2.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="0.9.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.Blob" version="9.4.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="9.4.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="0.10.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.File" version="9.4.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="9.3.2" targetFramework="net45" />
 </packages>

--- a/test/DMLibTest/Cases/AccessConditionTest.cs
+++ b/test/DMLibTest/Cases/AccessConditionTest.cs
@@ -81,7 +81,7 @@ namespace DMLibTest.Cases
 
         private void TestAccessCondition(SourceOrDest sourceOrDest)
         {
-            string eTag = "notmatch";
+            string eTag = "\"notmatch\"";
             AccessCondition accessCondition = new AccessCondition()
             {
                 IfMatchETag = eTag
@@ -147,10 +147,10 @@ namespace DMLibTest.Cases
             Exception exception = result.Exceptions[0];
 #if DNXCORE50
             VerificationHelper.VerifyTransferException(exception, TransferErrorCode.Unknown);
-
-            // TODO: The InnerException is as expected but has a different message and HttpStatusCode
-            // compared to the desktop version of XSCL; is this an XSCL bug?
-            VerificationHelper.VerifyStorageException(exception.InnerException, 0, "The format of value 'notmatch' is invalid.");
+            
+            // Verify innner StorageException
+            VerificationHelper.VerifyStorageException(exception.InnerException, (int)HttpStatusCode.PreconditionFailed,
+                "The condition specified using HTTP conditional header(s) is not met.");
 #else
             VerificationHelper.VerifyTransferException(exception, TransferErrorCode.Unknown);
 

--- a/test/DMLibTest/Cases/SnapshotTest.cs
+++ b/test/DMLibTest/Cases/SnapshotTest.cs
@@ -323,7 +323,7 @@ namespace DMLibTest.Cases
             Test.Assert(task.Result.NumberOfFilesTransferred == fileCount, string.Format("Transferred file :{0} == {1}", task.Result.NumberOfFilesTransferred, fileCount));
 
             // verify that Files in Share Snapshot is transferred
-            IEnumerable<IListFileItem> sourceFiles = SourceObject.ListFilesAndDirectories();
+            IEnumerable<IListFileItem> sourceFiles = SourceObject.ListFilesAndDirectories(HelperConst.DefaultFileOptions);
             foreach (IListFileItem item in sourceFiles)
             {
                 if (item is CloudFile)

--- a/test/DMLibTest/DMLibTest.csproj
+++ b/test/DMLibTest/DMLibTest.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DMLibTest</RootNamespace>
     <AssemblyName>DMLibTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -56,13 +56,18 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Blob, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Storage.Blob.9.4.2\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.Common, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Storage.Common.9.4.2\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=9.4.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Storage.File.9.4.2\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.3.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.Storage.9.3.2\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/test/DMLibTest/Framework/CloudObjectExtensions.cs
+++ b/test/DMLibTest/Framework/CloudObjectExtensions.cs
@@ -9,7 +9,6 @@ namespace DMLibTest
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.File;
     using Microsoft.WindowsAzure.Storage.RetryPolicies;
-    using Microsoft.WindowsAzure.Storage.Table;
 
     internal static class CloudObjectExtensions
     {
@@ -67,11 +66,6 @@ namespace DMLibTest
         };
 
         public static FileRequestOptions DefaultFileOptions = new FileRequestOptions
-        {
-            RetryPolicy = new LinearRetry(TimeSpan.FromSeconds(90), 3),
-        };
-
-        public static TableRequestOptions DefaultTableOptions = new TableRequestOptions
         {
             RetryPolicy = new LinearRetry(TimeSpan.FromSeconds(90), 3),
         };

--- a/test/DMLibTest/Framework/CloudObjectExtensions.cs
+++ b/test/DMLibTest/Framework/CloudObjectExtensions.cs
@@ -63,11 +63,13 @@ namespace DMLibTest
         public static BlobRequestOptions DefaultBlobOptions = new BlobRequestOptions
         {
             RetryPolicy = new LinearRetry(TimeSpan.FromSeconds(90), 3),
+            MaximumExecutionTime = TimeSpan.FromMinutes(15)
         };
 
         public static FileRequestOptions DefaultFileOptions = new FileRequestOptions
         {
             RetryPolicy = new LinearRetry(TimeSpan.FromSeconds(90), 3),
+            MaximumExecutionTime = TimeSpan.FromMinutes(15)
         };
     }
 }

--- a/test/DMLibTest/Framework/SharedAccessPermissions.cs
+++ b/test/DMLibTest/Framework/SharedAccessPermissions.cs
@@ -8,7 +8,6 @@ namespace DMLibTest
     using System;
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.File;
-    using Microsoft.WindowsAzure.Storage.Table;
 
     [Flags]
     public enum SharedAccessPermissions
@@ -37,11 +36,6 @@ namespace DMLibTest
         public static SharedAccessFilePermissions ToFilePermissions(this SharedAccessPermissions sap)
         {
             return (SharedAccessFilePermissions)Enum.Parse(typeof(SharedAccessFilePermissions), sap.ToString());
-        }
-
-        public static SharedAccessTablePermissions ToTablePermissions(this SharedAccessPermissions sap)
-        {
-            return (SharedAccessTablePermissions)Enum.Parse(typeof(SharedAccessTablePermissions), sap.ToString());
         }
 
         public static SharedAccessPermissions ToCommonPermissions(this Enum specificPermissions)

--- a/test/DMLibTest/Util/DMLibTestConstants.cs
+++ b/test/DMLibTest/Util/DMLibTestConstants.cs
@@ -9,6 +9,7 @@ namespace DMLibTest
     using Microsoft.WindowsAzure.Storage.DataMovement;
     using MS.Test.Common.MsTestLib;
     using Microsoft.WindowsAzure.Storage.RetryPolicies;
+    using Microsoft.WindowsAzure.Storage.Blob;
 
     public static class Tag
     {
@@ -116,6 +117,20 @@ namespace DMLibTest
 
                 Test.Verbose("Recursive folder depth: {0}", recursiveFolderDepth);
                 return recursiveFolderDepth;
+            }
+        }
+
+        internal static class RequestOptions
+        {
+            public static BlobRequestOptions DefaultBlobRequestOptions
+            {
+                get
+                {
+                    return new BlobRequestOptions()
+                    {
+                        MaximumExecutionTime = TimeSpan.FromMinutes(15)
+                    };
+                }
             }
         }
     }

--- a/test/DMLibTest/Util/DMLibTestConstants.cs
+++ b/test/DMLibTest/Util/DMLibTestConstants.cs
@@ -10,6 +10,7 @@ namespace DMLibTest
     using MS.Test.Common.MsTestLib;
     using Microsoft.WindowsAzure.Storage.RetryPolicies;
     using Microsoft.WindowsAzure.Storage.Blob;
+    using Microsoft.WindowsAzure.Storage.File;
 
     public static class Tag
     {
@@ -117,20 +118,6 @@ namespace DMLibTest
 
                 Test.Verbose("Recursive folder depth: {0}", recursiveFolderDepth);
                 return recursiveFolderDepth;
-            }
-        }
-
-        internal static class RequestOptions
-        {
-            public static BlobRequestOptions DefaultBlobRequestOptions
-            {
-                get
-                {
-                    return new BlobRequestOptions()
-                    {
-                        MaximumExecutionTime = TimeSpan.FromMinutes(15)
-                    };
-                }
             }
         }
     }

--- a/test/DMLibTest/Util/Helpers.cs
+++ b/test/DMLibTest/Util/Helpers.cs
@@ -82,7 +82,7 @@ namespace DMLibTest
             try
             {
                 CloudBlobContainer container = BlobClient.GetContainerReference(containerName);
-                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, BlobListingDetails.All);
+                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, BlobListingDetails.All, HelperConst.DefaultBlobOptions);
                 if (blobs != null)
                 {
                     foreach (CloudBlob blob in blobs)
@@ -1972,7 +1972,7 @@ namespace DMLibTest
                 localSubDirs.Add(Path.GetFileName(localSubDir));
             }
 
-            foreach (IListFileItem item in dir.ListFilesAndDirectories())
+            foreach (IListFileItem item in dir.ListFilesAndDirectories(HelperConst.DefaultFileOptions))
             {
                 if (item is CloudFile)
                 {
@@ -2117,7 +2117,7 @@ namespace DMLibTest
         public static IEnumerable<string> EnumerateFiles(CloudFileDirectory dir, bool recursive)
         {
             var folders = new List<CloudFileDirectory>();
-            foreach (IListFileItem item in dir.ListFilesAndDirectories())
+            foreach (IListFileItem item in dir.ListFilesAndDirectories(HelperConst.DefaultFileOptions))
             {
                 if (item is CloudFile)
                 {
@@ -2163,7 +2163,7 @@ namespace DMLibTest
         public static IEnumerable<string> EnumerateDirectories(CloudFileDirectory dir, bool recursive)
         {
             List<string> dirs = new List<string>();
-            foreach (IListFileItem item in dir.ListFilesAndDirectories())
+            foreach (IListFileItem item in dir.ListFilesAndDirectories(HelperConst.DefaultFileOptions))
             {
                 if (item is CloudFileDirectory)
                 {
@@ -2232,7 +2232,7 @@ namespace DMLibTest
             }
             else
             {
-                if (root.ListFilesAndDirectories().Count() > 500)
+                if (root.ListFilesAndDirectories(HelperConst.DefaultFileOptions).Count() > 500)
                     return CleanupFileShareByRecreateIt(shareName);
             }
 
@@ -2242,7 +2242,7 @@ namespace DMLibTest
 
         public static void CleanupFileDirectory(CloudFileDirectory cloudDirectory)
         {
-            foreach (IListFileItem item in cloudDirectory.ListFilesAndDirectories())
+            foreach (IListFileItem item in cloudDirectory.ListFilesAndDirectories(HelperConst.DefaultFileOptions))
             {
                 if (item is CloudFile)
                 {
@@ -2498,7 +2498,7 @@ namespace DMLibTest
             try
             {
                 CloudBlobContainer container = BlobClient.GetContainerReference(containerName);
-                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, listingDetails);
+                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, listingDetails, HelperConst.DefaultBlobOptions);
                 if (blobs != null)
                 {
                     foreach (CloudBlob blob in blobs)
@@ -2687,7 +2687,7 @@ namespace DMLibTest
                 CloudBlobContainer container = BlobClient.GetContainerReference(containerName);
                 if (!container.Exists())
                     return true;
-                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, BlobListingDetails.All, DMLibTestConstants.RequestOptions.DefaultBlobRequestOptions);
+                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, BlobListingDetails.All, HelperConst.DefaultBlobOptions);
                 if (blobs != null)
                 {
                     if (blobs.Count() > 500)
@@ -2722,7 +2722,7 @@ namespace DMLibTest
                 }
 
                 Thread.Sleep(5 * 1000);
-                if (container.ListBlobs(null, true, BlobListingDetails.All, DMLibTestConstants.RequestOptions.DefaultBlobRequestOptions).Any())
+                if (container.ListBlobs(null, true, BlobListingDetails.All, HelperConst.DefaultBlobOptions).Any())
                 {
                     Test.Warn("The container hasn't been cleaned actually.");
                     Test.Info("Trying to cleanup the container by recreating it...");
@@ -3371,7 +3371,7 @@ namespace DMLibTest
                 CloudBlobContainer container = BlobClient.GetContainerReference(containerName);
                 if (container.Exists())
                 {
-                    IEnumerable<IListBlobItem> blobs = container.ListBlobs(blobName, true, BlobListingDetails.All);
+                    IEnumerable<IListBlobItem> blobs = container.ListBlobs(blobName, true, BlobListingDetails.All, HelperConst.DefaultBlobOptions);
                     foreach (CloudBlob blob in blobs)
                     {
                         if (blob.Name == blobName)

--- a/test/DMLibTest/Util/Helpers.cs
+++ b/test/DMLibTest/Util/Helpers.cs
@@ -18,16 +18,13 @@ namespace DMLibTest
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
-
+    using DMLibTest.Framework;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Auth;
     using Microsoft.WindowsAzure.Storage.Blob;
     using Microsoft.WindowsAzure.Storage.File;
     using Microsoft.WindowsAzure.Storage.RetryPolicies;
-    using Microsoft.WindowsAzure.Storage.Table;
     using MS.Test.Common.MsTestLib;
-
-    using DMLibTest.Framework;
     using StorageBlobType = Microsoft.WindowsAzure.Storage.Blob.BlobType;
 
     /// <summary>
@@ -106,7 +103,7 @@ namespace DMLibTest
         public static void WaitForTakingEffect(dynamic cloudStorageClient)
         {
             Test.Assert(
-                cloudStorageClient is CloudBlobClient || cloudStorageClient is CloudTableClient || cloudStorageClient is CloudFileClient,
+                cloudStorageClient is CloudBlobClient || cloudStorageClient is CloudFileClient,
                 "The argument should only be CloudStorageClient.");
 
             if (DMLibTestHelper.GetTestAgainst() != TestAgainst.PublicAzure)
@@ -2690,7 +2687,7 @@ namespace DMLibTest
                 CloudBlobContainer container = BlobClient.GetContainerReference(containerName);
                 if (!container.Exists())
                     return true;
-                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, BlobListingDetails.All);
+                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, BlobListingDetails.All, RequestOptions.DefaultBlobRequestOptions);
                 if (blobs != null)
                 {
                     if (blobs.Count() > 500)
@@ -2725,7 +2722,7 @@ namespace DMLibTest
                 }
 
                 Thread.Sleep(5 * 1000);
-                if (container.ListBlobs(null, true, BlobListingDetails.All).Any())
+                if (container.ListBlobs(null, true, BlobListingDetails.All, RequestOptions.DefaultBlobRequestOptions).Any())
                 {
                     Test.Warn("The container hasn't been cleaned actually.");
                     Test.Info("Trying to cleanup the container by recreating it...");
@@ -2736,7 +2733,7 @@ namespace DMLibTest
                     return true;
                 }
             }
-            catch (Exception e) when (Helper.IsNotFoundStorageException(e) || Helper.IsConflictStorageException(e))
+            catch (Exception e) when (Helper.IsNotFoundStorageException(e) || Helper.IsConflictStorageException(e) || e is OperationCanceledException)
             {
                 return CleanupContainerByRecreateIt(containerName);
             }

--- a/test/DMLibTest/Util/Helpers.cs
+++ b/test/DMLibTest/Util/Helpers.cs
@@ -2687,7 +2687,7 @@ namespace DMLibTest
                 CloudBlobContainer container = BlobClient.GetContainerReference(containerName);
                 if (!container.Exists())
                     return true;
-                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, BlobListingDetails.All, RequestOptions.DefaultBlobRequestOptions);
+                IEnumerable<IListBlobItem> blobs = container.ListBlobs(null, true, BlobListingDetails.All, DMLibTestConstants.RequestOptions.DefaultBlobRequestOptions);
                 if (blobs != null)
                 {
                     if (blobs.Count() > 500)
@@ -2722,7 +2722,7 @@ namespace DMLibTest
                 }
 
                 Thread.Sleep(5 * 1000);
-                if (container.ListBlobs(null, true, BlobListingDetails.All, RequestOptions.DefaultBlobRequestOptions).Any())
+                if (container.ListBlobs(null, true, BlobListingDetails.All, DMLibTestConstants.RequestOptions.DefaultBlobRequestOptions).Any())
                 {
                     Test.Warn("The container hasn't been cleaned actually.");
                     Test.Info("Trying to cleanup the container by recreating it...");

--- a/test/DMLibTest/app.config
+++ b/test/DMLibTest/app.config
@@ -12,4 +12,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/test/DMLibTest/packages.config
+++ b/test/DMLibTest/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.Storage.Blob" version="9.4.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="9.4.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.File" version="9.4.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />

--- a/test/DMLibTestCodeGen/App.config
+++ b/test/DMLibTestCodeGen/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/test/DMLibTestCodeGen/DMLibTestCodeGen.csproj
+++ b/test/DMLibTestCodeGen/DMLibTestCodeGen.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DMLibTestCodeGen</RootNamespace>
     <AssemblyName>DMLibTestCodeGen</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/test/DMTestLib/DMTestLib.csproj
+++ b/test/DMTestLib/DMTestLib.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DMTestLib</RootNamespace>
     <AssemblyName>DMTestLib</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/test/MsTestLib/MsTestLib.csproj
+++ b/test/MsTestLib/MsTestLib.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>MS.Test.Common.MsTestLib</RootNamespace>
     <AssemblyName>MsTestLib</AssemblyName>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyVersion("0.9.1.0")]
+[assembly: AssemblyFileVersion("0.9.1.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]
-[assembly: AssemblyCopyright("Copyright © 2018 Microsoft Corp.")]
+[assembly: AssemblyCopyright("Copyright © 2019 Microsoft Corp.")]
 [assembly: AssemblyTrademark("Microsoft ® is a registered trademark of Microsoft Corporation.")]
 [assembly: AssemblyCulture("")]
 

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.10.0.0")]
-[assembly: AssemblyFileVersion("0.10.0.0")]
+[assembly: AssemblyVersion("0.10.1.0")]
+[assembly: AssemblyFileVersion("0.10.1.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.9.1.0")]
-[assembly: AssemblyFileVersion("0.9.1.0")]
+[assembly: AssemblyVersion("0.10.0.0")]
+[assembly: AssemblyFileVersion("0.10.0.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -19,12 +19,14 @@
     <dependencies>
       <group targetFramework="net45">
         <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" />
-        <dependency id="WindowsAzure.Storage" version="9.3.2" />
+        <dependency id="Microsoft.Azure.Storage.File" version="9.4.2" />
+        <dependency id="Microsoft.Azure.Storage.Blob" version="9.4.2" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Mono.Posix.NETStandard" version="1.0.0-beta2" />
         <dependency id="NETStandard.Library" version="2.0.1" />
-        <dependency id="WindowsAzure.Storage" version="9.3.2" />
+        <dependency id="Microsoft.Azure.Storage.File" version="9.4.2" />
+        <dependency id="Microsoft.Azure.Storage.Blob" version="9.4.2" />
         <dependency id="System.Runtime.Serialization.Xml" version="4.3.0" />
         <dependency id="System.Threading.ThreadPool" version="4.3.0" />
       </group>

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>0.9.0</version>
+    <version>0.9.1</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -17,7 +17,7 @@
     <summary>A client library designed for high-performance and scalable uploading, downloading and copying data to and from Microsoft Azure Blob and File Storage</summary>
     <tags>Microsoft, Azure, Storage, Blob, File, DataMovement, Upload, Download, Copy, High-Performance, Scalable, Reliable, windowsazureofficial</tags>
     <dependencies>
-      <group targetFramework="net45">
+      <group targetFramework="net452">
         <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" />
         <dependency id="Microsoft.Azure.Storage.File" version="9.4.2" />
         <dependency id="Microsoft.Azure.Storage.Blob" version="9.4.2" />
@@ -32,7 +32,7 @@
       </group>
     </dependencies>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Data" targetFramework="net45" />
+      <frameworkAssembly assemblyName="System.Data" targetFramework="net452" />
       <frameworkAssembly assemblyName="System.Xml" targetFramework="" />
       <frameworkAssembly assemblyName="System.Xml.Linq" targetFramework="" />
     </frameworkAssemblies>

--- a/tools/nupkg/buildDebugNupkg.cmd
+++ b/tools/nupkg/buildDebugNupkg.cmd
@@ -2,13 +2,13 @@ pushd %~dp0
 rmdir /s /q .\workspace
 mkdir .\workspace
 copy .\Microsoft.Azure.Storage.DataMovement.nuspec .\workspace
-mkdir .\workspace\lib\net45
+mkdir .\workspace\lib\net452
 mkdir .\workspace\lib\netstandard2.0
 pushd ..\..
 del /q /f *.nupkg
-copy .\lib\bin\Debug\Microsoft.WindowsAzure.Storage.DataMovement.dll .\tools\nupkg\workspace\lib\net45
-copy .\lib\bin\Debug\Microsoft.WindowsAzure.Storage.DataMovement.pdb .\tools\nupkg\workspace\lib\net45
-copy .\lib\bin\Debug\Microsoft.WindowsAzure.Storage.DataMovement.XML .\tools\nupkg\workspace\lib\net45
+copy .\lib\bin\Debug\Microsoft.WindowsAzure.Storage.DataMovement.dll .\tools\nupkg\workspace\lib\net452
+copy .\lib\bin\Debug\Microsoft.WindowsAzure.Storage.DataMovement.pdb .\tools\nupkg\workspace\lib\net452
+copy .\lib\bin\Debug\Microsoft.WindowsAzure.Storage.DataMovement.XML .\tools\nupkg\workspace\lib\net452
 copy .\netcore\Microsoft.WindowsAzure.Storage.DataMovement\bin\Debug\netstandard2.0\Microsoft.WindowsAzure.Storage.DataMovement.dll .\tools\nupkg\workspace\lib\netstandard2.0
 copy .\netcore\Microsoft.WindowsAzure.Storage.DataMovement\bin\Debug\netstandard2.0\Microsoft.WindowsAzure.Storage.DataMovement.pdb .\tools\nupkg\workspace\lib\netstandard2.0
 copy .\netcore\Microsoft.WindowsAzure.Storage.DataMovement\bin\Debug\netstandard2.0\Microsoft.WindowsAzure.Storage.DataMovement.xml .\tools\nupkg\workspace\lib\netstandard2.0

--- a/tools/nupkg/buildNupkg.cmd
+++ b/tools/nupkg/buildNupkg.cmd
@@ -2,13 +2,13 @@ pushd %~dp0
 rmdir /s /q .\workspace
 mkdir .\workspace
 copy .\Microsoft.Azure.Storage.DataMovement.nuspec .\workspace
-mkdir .\workspace\lib\net45
+mkdir .\workspace\lib\net452
 mkdir .\workspace\lib\netstandard2.0
 pushd ..\..
 del /q /f *.nupkg
-copy .\lib\bin\Release\Microsoft.WindowsAzure.Storage.DataMovement.dll .\tools\nupkg\workspace\lib\net45
-copy .\lib\bin\Release\Microsoft.WindowsAzure.Storage.DataMovement.pdb .\tools\nupkg\workspace\lib\net45
-copy .\lib\bin\Release\Microsoft.WindowsAzure.Storage.DataMovement.XML .\tools\nupkg\workspace\lib\net45
+copy .\lib\bin\Release\Microsoft.WindowsAzure.Storage.DataMovement.dll .\tools\nupkg\workspace\lib\net452
+copy .\lib\bin\Release\Microsoft.WindowsAzure.Storage.DataMovement.pdb .\tools\nupkg\workspace\lib\net452
+copy .\lib\bin\Release\Microsoft.WindowsAzure.Storage.DataMovement.XML .\tools\nupkg\workspace\lib\net452
 copy .\netcore\Microsoft.WindowsAzure.Storage.DataMovement\bin\Release\netstandard2.0\Microsoft.WindowsAzure.Storage.DataMovement.dll .\tools\nupkg\workspace\lib\netstandard2.0
 copy .\netcore\Microsoft.WindowsAzure.Storage.DataMovement\bin\Release\netstandard2.0\Microsoft.WindowsAzure.Storage.DataMovement.pdb .\tools\nupkg\workspace\lib\netstandard2.0
 copy .\netcore\Microsoft.WindowsAzure.Storage.DataMovement\bin\Release\netstandard2.0\Microsoft.WindowsAzure.Storage.DataMovement.xml .\tools\nupkg\workspace\lib\netstandard2.0


### PR DESCRIPTION
1. Upgrade to Azure Storage Client Library 9.4.2
2. Fix issue of config to disable content MD5 checking in download doesn't take effect during resuming
3. Fix issue of hang when uploading from a non-fixed sized stream
4. Fix issue of block id may not be correct when changing BlockSize during uploading from a non-fixed sized stream to block blob