### PR TITLE
Preserving SMB permission and other improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Microsoft Azure Storage Data Movement Library (1.1.0)
+# Microsoft Azure Storage Data Movement Library (1.2.0)
 
 The Microsoft Azure Storage Data Movement Library designed for high-performance uploading, downloading and copying Azure Storage Blob and File. This library is based on the core data movement framework that powers [AzCopy](https://azure.microsoft.com/documentation/articles/storage-use-azcopy/).
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+2019.12.17 Version 1.2.0
+ * All Service on both .Net Framework and .Net Core
+   - Upgraded Microsoft.Azure.Storage.Blob from 11.1.0 to 11.1.1
+   - Upgraded Microsoft.Azure.Storage.File from 11.1.0 to 11.1.1
+   - Changed to not send request to query copying status when the Service Side Synchronous Copy can be completed when StartCopy request returns.
+ * File Service on both .Net Framework and .Net Core
+   - Added support to preserve file permission when uploading/downloading from/to local file directory to/from Azure File directory on Windows.
+   - Removed client side file size limitation checking and changed to leverage server side file size checking when transferring destination is Azure File.
+
 2019.09.29 Version 1.1.0
  * All Service on both .Net Framework and .Net Core
    - Upgraded Microsoft.Azure.Storage.Blob from 10.0.3 to 11.1.0

--- a/lib/AzureFileDirectorySDDLCache.cs
+++ b/lib/AzureFileDirectorySDDLCache.cs
@@ -1,0 +1,98 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="AzureFileDirectorySDDLCache.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Storage.DataMovement
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    // Cache for SDDL permission string and permission key mapping.
+    // For uploading from local file directory to Azure File Directory, key is SDDL string, value is permission key.
+    // For downloading from Azure File Directory to local file directory, key is permission, value is SDDL string.
+    internal class AzureFileDirectorySDDLCache : IDisposable
+    {
+        private Dictionary<string, string> sddlPermissionKey = new Dictionary<string, string>();
+        private Queue<string> dictionaryKeys = new Queue<string>();
+        private ReaderWriterLockSlim cacheLock = new ReaderWriterLockSlim();
+        private int itemCount = 0;
+        private const int MaximumItemCount = 128;
+
+        public AzureFileDirectorySDDLCache()
+        { }
+
+        public string GetValue(string key)
+        {
+            this.cacheLock.EnterReadLock();
+            try
+            {
+                string value = null;
+                sddlPermissionKey.TryGetValue(key, out value);
+                return value;
+            }
+            finally
+            {
+                this.cacheLock.ExitReadLock();
+            }
+        }
+
+        public void AddValue(string key, string value)
+        {
+            this.cacheLock.EnterWriteLock();
+            try
+            {
+                string originValue = null;
+                if (sddlPermissionKey.TryGetValue(key, out originValue))
+                {
+                    return;
+                }
+
+                if ((this.itemCount + 1) > MaximumItemCount)
+                {
+                    string keyToBeRemoved = this.dictionaryKeys.Dequeue();
+                    this.sddlPermissionKey.Remove(keyToBeRemoved);
+                }
+                else
+                {
+                    ++this.itemCount;
+                }
+                this.sddlPermissionKey.Add(key, value);
+                this.dictionaryKeys.Enqueue(key);
+            }
+            finally
+            {
+                this.cacheLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Public dispose method to release all resources owned.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Private dispose method to release managed/unmanaged objects.
+        /// If disposing = true clean up managed resources as well as unmanaged resources.
+        /// If disposing = false only clean up unmanaged resources.
+        /// </summary>
+        /// <param name="disposing">Indicates whether or not to dispose managed resources.</param>
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (null != this.cacheLock)
+                {
+                    this.cacheLock.Dispose();
+                    this.cacheLock = null;
+                }
+            }
+        }
+    }
+}

--- a/lib/Constants.cs
+++ b/lib/Constants.cs
@@ -40,6 +40,14 @@ namespace Microsoft.Azure.Storage.DataMovement
         public const string DirectoryBlobMetadataKey = "hdi_isfolder";
 
         /// <summary>
+        /// Maximum length for SDDL string to be set in x-ms-permission header. 
+        /// For SDDL string longer than this value, should invoke CreatePermission on Share first and then set permission-key to x-ms-permission-key header.
+        /// It allows at most 8KB length for a header value. 
+        /// Here use a value which is a bit smaller than 8KB to gurantee success of REST call.
+        /// </summary>
+        internal const int MaxSDDLLengthInProperties = 8100;
+
+        /// <summary>
         /// Maximum windows file path is 260 characters, including a terminating NULL characters.
         /// This leaves 259 useable characters.
         /// </summary>

--- a/lib/Constants.cs
+++ b/lib/Constants.cs
@@ -90,11 +90,6 @@ namespace Microsoft.Azure.Storage.DataMovement
         internal const long MaxBlockBlobFileSize = (long)50000 * 100 * 1024 * 1024;
 
         /// <summary>
-        /// Stores the max cloud file size, 1TB.
-        /// </summary>
-        internal const long MaxCloudFileSize = (long)1024 * 1024 * 1024 * 1024;
-
-        /// <summary>
         /// Max transfer window size. 
         /// There can be multiple threads to transfer a file, 
         /// and we need to record transfer window 
@@ -162,7 +157,12 @@ namespace Microsoft.Azure.Storage.DataMovement
         internal const int ListSegmentLengthMultiplier = 8;
 
         internal const string BlobTypeMismatch = "Blob type of the blob reference doesn't match blob type of the blob.";
-        
+
+        /// <summary>
+        /// Error code message returned from Azure Storage Server when length of the Azure File is longer than allowed.
+        /// </summary>
+        internal const string FileSizeOutOfRangeErrorCode = "OutOfRangeInput";
+
         /// <summary>
         /// The maximum size of a block blob that can be uploaded with a single Put Blob request.
         /// </summary>

--- a/lib/DataMovement.csproj
+++ b/lib/DataMovement.csproj
@@ -54,14 +54,14 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.Blob, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.11.1.0\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.Blob, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.11.1.1\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.Common, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.1.0\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.Common, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.1.1\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.File, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.File.11.1.0\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.File.11.1.1\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>

--- a/lib/DataMovement.csproj
+++ b/lib/DataMovement.csproj
@@ -84,6 +84,7 @@
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="AzureFileDirectorySDDLCache.cs" />
     <Compile Include="ChunkedMemoryStream.cs" />
     <Compile Include="CopyMethod.cs" />
     <Compile Include="DirectoryListingScheduler.cs" />

--- a/lib/DataMovement.csproj
+++ b/lib/DataMovement.csproj
@@ -89,8 +89,11 @@
     <Compile Include="DirectoryListingScheduler.cs" />
     <Compile Include="Extensions\StorageCopyState.cs" />
     <Compile Include="FileNativeMethods.cs" />
+    <Compile Include="FileSecurityNativeMethods.cs" />
+    <Compile Include="FileSecurityOperations.cs" />
     <Compile Include="LongPathFile.cs" />
     <Compile Include="LongPathFileStream.cs" />
+    <Compile Include="PreserveSMBPermissions.cs" />
     <Compile Include="TestHook\FaultInjectionPoint.cs" />
     <Compile Include="DirectoryTransferContext.cs" />
     <Compile Include="Interop\Interop.cs" />

--- a/lib/Extensions/StorageCopyState.cs
+++ b/lib/Extensions/StorageCopyState.cs
@@ -120,11 +120,11 @@ namespace Microsoft.Azure.Storage.DataMovement.Extensions
         //
         // Summary:
         //     Gets the number of bytes copied in the operation so far.
-        public long? BytesCopied { get; private set; }
+        public long? BytesCopied { get; set; }
         //
         // Summary:
         //     Gets the total number of bytes in the source of the copy.
-        public long? TotalBytes { get; private set; }
+        public long? TotalBytes { get; set; }
         //
         // Summary:
         //     Gets the description of the current status, if any.

--- a/lib/FileSecurityNativeMethods.cs
+++ b/lib/FileSecurityNativeMethods.cs
@@ -1,0 +1,170 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="FileSecurityNativeMethods.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Storage.DataMovement.Interop
+{
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Text;
+
+    internal static partial class NativeMethods
+    {
+        public const int SE_PRIVILEGE_ENABLED = 0x00000002;
+        public const int SE_PRIVILEGE_DISABLED = 0x00000000;
+
+        public const int ERROR_NOT_ALL_ASSIGNED = 1300;
+        public const int ERROR_PRIVILEGE_NOT_HELD = 1314;
+        public const int ERROR_INSUFFICIENT_BUFFER = 122;
+        public const int SDDL_REVISION_1 = 1;
+
+        public const string SACLPrivilegeName = "SeSecurityPrivilege";
+        public const string OwnerPrivilegeName = "SeRestorePrivilege";
+
+        [Flags]
+        public enum SECURITY_INFORMATION : uint
+        {
+            OWNER_SECURITY_INFORMATION = 0x00000001,
+            GROUP_SECURITY_INFORMATION = 0x00000002,
+            DACL_SECURITY_INFORMATION = 0x00000004,
+            SACL_SECURITY_INFORMATION = 0x00000008,
+            UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000,
+            UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000,
+            PROTECTED_SACL_SECURITY_INFORMATION = 0x40000000,
+            PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+        }
+
+        public enum SE_OBJECT_TYPE
+        {
+            SE_UNKNOWN_OBJECT_TYPE = 0,
+            SE_FILE_OBJECT,
+            SE_SERVICE,
+            SE_PRINTER,
+            SE_REGISTRY_KEY,
+            SE_LMSHARE,
+            SE_KERNEL_OBJECT,
+            SE_WINDOW_OBJECT,
+            SE_DS_OBJECT,
+            SE_DS_OBJECT_ALL,
+            SE_PROVIDER_DEFINED_OBJECT,
+            SE_WMIGUID_OBJECT,
+            SE_REGISTRY_WOW64_32KEY
+        }
+
+        public enum SID_NAME_USE
+        {
+            SidTypeUser,
+            SidTypeGroup,
+            SidTypeDomain,
+            SidTypeAlias,
+            SidTypeWellKnownGroup,
+            SidTypeDeletedAccount,
+            SidTypeInvalid,
+            SidTypeUnknown,
+            SidTypeComputer,
+            SidTypeLabel,
+            SidTypeLogonSession
+        };
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct LUID
+        {
+            public UInt32 LowPart;
+            public Int32 HighPart;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct LUID_AND_ATTRIBUTES
+        {
+            public LUID Luid;
+            public UInt32 Attributes;
+        }
+
+        public struct TOKEN_PRIVILEGES
+        {
+            public int PrivilegeCount;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)]
+            public LUID_AND_ATTRIBUTES[] Privileges;
+        }
+
+        #region Get/Set FileDDL
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api")]
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetUserName(StringBuilder sb, ref Int32 length);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool LookupAccountName(
+            string lpSystemName,
+            string lpAccountName,
+            [MarshalAs(UnmanagedType.LPArray)] byte[] Sid,
+            ref uint cbSid,
+            StringBuilder ReferencedDomainName,
+            ref uint cchReferencedDomainName,
+            out SID_NAME_USE peUse);
+
+        [DllImport("advapi32", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetWindowsAccountDomainSid(
+            [MarshalAs(UnmanagedType.LPArray)] byte[] sid,
+            [MarshalAs(UnmanagedType.LPArray)] byte[] domainSid,
+            ref uint length);
+
+        [DllImport("advapi32.dll", EntryPoint = "GetNamedSecurityInfoW", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern uint GetNamedSecurityInfoW(
+                 string pObjectName,
+                 SE_OBJECT_TYPE ObjectType,
+                 SECURITY_INFORMATION SecurityInfo,
+                 out IntPtr pSidOwner,
+                 out IntPtr pSidGroup,
+                 out IntPtr pDacl,
+                 out IntPtr pSacl,
+                 out IntPtr pSecurityDescriptor);
+
+        [DllImport("Advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern void SetFileSecurity(string path, int type_of_sd, IntPtr sd);
+
+        [DllImport("kernel32.dll", EntryPoint = "LocalFree", SetLastError = true)]
+        public static extern IntPtr LocalFree(IntPtr handle);
+
+        [DllImport("advapi32", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ConvertSidToStringSid([MarshalAs(UnmanagedType.LPArray)] byte[] sid, out IntPtr ptrSid);
+
+        // Call LocalFree to free SecurityDescriptor pointer.
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ConvertStringSecurityDescriptorToSecurityDescriptor(
+               string StringSecurityDescriptor,
+               uint StringSDRevision,
+               out IntPtr SecurityDescriptor,
+               out UIntPtr SecurityDescriptorSize);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ConvertSecurityDescriptorToStringSecurityDescriptor(
+            IntPtr SecurityDescriptor,
+            uint StringSDRevision,
+            SECURITY_INFORMATION SecurityInformation,
+            out IntPtr StringSecurityDescriptor,
+            out UIntPtr StringSecurityDescriptorLen);
+        #endregion
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool AdjustTokenPrivileges(IntPtr TokenHandle,
+           [MarshalAs(UnmanagedType.Bool)]bool DisableAllPrivileges,
+           ref TOKEN_PRIVILEGES NewState,
+           UInt32 BufferLengthInBytes,
+           ref TOKEN_PRIVILEGES PreviousState,
+           out UInt32 ReturnLengthInBytes);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool LookupPrivilegeValue(string lpSystemName, string lpName,
+            ref LUID lpLuid);
+    }
+}

--- a/lib/FileSecurityNativeMethods.cs
+++ b/lib/FileSecurityNativeMethods.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Azure.Storage.DataMovement.Interop
         public const int SE_PRIVILEGE_ENABLED = 0x00000002;
         public const int SE_PRIVILEGE_DISABLED = 0x00000000;
 
+        public const int ERROR_ACCESS_DENIED = 5;
         public const int ERROR_NOT_ALL_ASSIGNED = 1300;
+        public const int ERROR_INVALID_OWNER = 1307;
         public const int ERROR_PRIVILEGE_NOT_HELD = 1314;
         public const int ERROR_INSUFFICIENT_BUFFER = 122;
         public const int SDDL_REVISION_1 = 1;

--- a/lib/FileSecurityOperations.cs
+++ b/lib/FileSecurityOperations.cs
@@ -1,0 +1,639 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="FileSecurityOperations.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Storage.DataMovement
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Linq;
+    using System.Runtime.InteropServices;
+    using System.Security.Principal;
+    using System.Text;
+    using Microsoft.Azure.Storage.DataMovement.Interop;
+
+    internal static class FileSecurityOperations
+    {
+        private static long OwnerPrivilegeJobCount = 0;
+        private static long SACLPrivilegeJobCount = 0;
+
+        private static object OwnerPrivilegeLock = new object();
+        private static object SACLPrivilegeLock = new object();
+
+        private static bool OwnerPrivilegeEnabledOriginal = false;
+        private static bool SACLPrivilegeEnabledOriginal = false;
+
+        private static bool OwnerPrivilegeEnabled = false;
+        private static bool SACLPrivilegeEnabled = false;
+
+        public static void BeginTransferJob(PreserveSMBPermissions preserveSMBPermissions, bool setLocalFilePermission)
+        {
+            if (PreserveSMBPermissions.PreserveSACLPermission == (preserveSMBPermissions & PreserveSMBPermissions.PreserveSACLPermission))
+            {
+                if (!SACLPrivilegeEnabledOriginal)
+                {
+                    lock (SACLPrivilegeLock)
+                    {
+                        if (SACLPrivilegeEnabledOriginal)
+                        {
+                            return;
+                        }
+
+                        ++SACLPrivilegeJobCount;
+
+                        if (SACLPrivilegeEnabled)
+                        {
+                            return;
+                        }
+
+                        try
+                        {
+                            SACLPrivilegeEnabledOriginal = SetPrivilege(NativeMethods.SACLPrivilegeName, true);
+                        }
+                        catch (Exception)
+                        {
+                            --SACLPrivilegeJobCount;
+                            throw;
+                        }
+
+                        SACLPrivilegeEnabled = true;
+
+                        if (SACLPrivilegeEnabledOriginal)
+                        {
+                            --SACLPrivilegeJobCount;
+                        }
+                    }
+                }
+            }
+
+            if (!setLocalFilePermission)
+            {
+                return;
+            }
+
+            if (PreserveSMBPermissions.PreserveOwnerPermission == (preserveSMBPermissions & PreserveSMBPermissions.PreserveOwnerPermission))
+            {
+                if (!OwnerPrivilegeEnabledOriginal)
+                {
+                    lock (OwnerPrivilegeLock)
+                    {
+                        if (OwnerPrivilegeEnabledOriginal)
+                        {
+                            return;
+                        }
+
+                        ++OwnerPrivilegeJobCount;
+
+                        if (OwnerPrivilegeEnabled)
+                        {
+                            return;
+                        }
+
+                        try
+                        {
+                            OwnerPrivilegeEnabledOriginal = SetPrivilege(NativeMethods.OwnerPrivilegeName, true);
+                        }
+                        catch (COMException)
+                        { }
+                        catch (TransferException)
+                        { }
+
+                        OwnerPrivilegeEnabled = true;
+
+                        if (OwnerPrivilegeEnabledOriginal)
+                        {
+                            --OwnerPrivilegeJobCount;
+                        }
+                    }
+                }
+            }
+        }
+
+        public static void EndTransferJob(PreserveSMBPermissions preserveSMBPermissions, bool setLocalFilePermission)
+        {
+            if (PreserveSMBPermissions.PreserveSACLPermission == (preserveSMBPermissions & PreserveSMBPermissions.PreserveSACLPermission))
+            {
+                if (!SACLPrivilegeEnabledOriginal)
+                {
+                    lock (SACLPrivilegeLock)
+                    {
+                        if (SACLPrivilegeEnabledOriginal)
+                        {
+                            return;
+                        }
+
+                        --SACLPrivilegeJobCount;
+
+                        if (0 == SACLPrivilegeJobCount)
+                        {
+                            try
+                            {
+                                SetPrivilege(NativeMethods.SACLPrivilegeName, false);
+                            }
+                            catch (TransferException)
+                            { }
+                            catch (COMException)
+                            { }
+                        }
+
+                        SACLPrivilegeEnabled = false;
+                    }
+                }
+            }
+
+            if (!setLocalFilePermission)
+            {
+                return;
+            }
+
+            if (PreserveSMBPermissions.PreserveOwnerPermission == (preserveSMBPermissions & PreserveSMBPermissions.PreserveOwnerPermission))
+            {
+                if (!OwnerPrivilegeEnabledOriginal)
+                {
+                    lock (OwnerPrivilegeLock)
+                    {
+                        if (OwnerPrivilegeEnabledOriginal)
+                        {
+                            return;
+                        }
+
+                        --OwnerPrivilegeJobCount;
+
+                        if (0 == OwnerPrivilegeJobCount)
+                        {
+                            try
+                            {
+                                SetPrivilege(NativeMethods.OwnerPrivilegeName, false);
+                            }
+                            catch (TransferException)
+                            { }
+                            catch (COMException)
+                            { }
+                        }
+
+                        OwnerPrivilegeEnabled = false;
+                    }
+                }
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Interoperability", "CA1404:CallGetLastErrorImmediatelyAfterPInvoke")]
+        private static bool SetPrivilege(
+               string securityPrivilege,
+               bool bEnablePrivilege   // to enable or disable privilege
+               )
+        {
+            var identity = WindowsIdentity.GetCurrent(TokenAccessLevels.AdjustPrivileges | TokenAccessLevels.Query);
+            var accessToken = identity.Token;
+
+            NativeMethods.TOKEN_PRIVILEGES tp;
+            NativeMethods.LUID luid = new NativeMethods.LUID();
+
+            if (!NativeMethods.LookupPrivilegeValue(
+                    null,            // lookup privilege on local system
+                    securityPrivilege,   // privilege to lookup 
+                    ref luid))        // receives LUID of privilege
+            {
+                throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
+
+            tp.PrivilegeCount = 1;
+            tp.Privileges = new NativeMethods.LUID_AND_ATTRIBUTES[1];
+            tp.Privileges[0].Luid = luid;
+            if (bEnablePrivilege)
+                tp.Privileges[0].Attributes = NativeMethods.SE_PRIVILEGE_ENABLED;
+            else
+                tp.Privileges[0].Attributes = NativeMethods.SE_PRIVILEGE_DISABLED;
+
+            NativeMethods.TOKEN_PRIVILEGES previousPrivileges = new NativeMethods.TOKEN_PRIVILEGES();
+            uint previousPrivilegesLength = 0;
+
+            // Enable the privilege or disable all privileges.
+            bool succeeded = NativeMethods.AdjustTokenPrivileges(
+                   accessToken,
+                   false,
+                   ref tp,
+                   1024,
+                   ref previousPrivileges,
+                   out previousPrivilegesLength);
+
+            if (!succeeded)
+            {
+                throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
+            else if (Marshal.GetLastWin32Error() == NativeMethods.ERROR_NOT_ALL_ASSIGNED)
+            {
+                throw new TransferException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.FailedToEnablePrivilegeException,
+                        securityPrivilege));
+            }
+
+            if ((previousPrivileges.Privileges.Count() == 1)
+                && (previousPrivileges.Privileges[0].Luid.LowPart == luid.LowPart)
+                && (previousPrivileges.Privileges[0].Luid.HighPart == luid.HighPart)
+                && (previousPrivileges.Privileges[0].Attributes == NativeMethods.SE_PRIVILEGE_ENABLED))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static void SetFileSecurity(string filePath, string portableSDDL, PreserveSMBPermissions preserveSMBPermissions)
+        {
+            if (PreserveSMBPermissions.None == preserveSMBPermissions) return;
+
+            if (string.IsNullOrEmpty(portableSDDL)) return;
+
+            IntPtr pSecurityDescriptor = new IntPtr();
+            UIntPtr securityDescriptorLength = new UIntPtr();
+
+            if (!NativeMethods.ConvertStringSecurityDescriptorToSecurityDescriptor(portableSDDL,
+                                                                         NativeMethods.SDDL_REVISION_1,
+                                                                         out pSecurityDescriptor,
+                                                                         out securityDescriptorLength))
+            {
+                throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
+
+            try
+            {
+                NativeMethods.SetFileSecurity(filePath,
+                        (int)(ToSecurityInfo(preserveSMBPermissions)),
+                    pSecurityDescriptor);
+
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (errorCode == NativeMethods.ERROR_PRIVILEGE_NOT_HELD)
+                {
+                    throw new TransferException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Resources.PrivilegeRequiredException,
+                            "https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setnamedsecurityinfow"));
+                }
+                else if (errorCode != 0)
+                {
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+            }
+            finally
+            {
+                NativeMethods.LocalFree(pSecurityDescriptor);
+            }
+        }
+
+        public static string GetFilePortableSDDL(
+            string filePath,
+            PreserveSMBPermissions preserveSMBPermissions)
+        {
+            if (preserveSMBPermissions == PreserveSMBPermissions.None)
+            {
+                return null;
+            }
+
+            string sddl = GetFileSDDL(filePath, ToSecurityInfo(preserveSMBPermissions));
+            string userName = GetUserName();
+            string domainSid = GetDomainSid(userName);
+            return GetPortableSDDL(sddl, domainSid);
+        }
+
+        private static NativeMethods.SECURITY_INFORMATION ToSecurityInfo(PreserveSMBPermissions preserveSMBPermissions)
+        {
+            uint securityInfo = 0;
+
+            if (PreserveSMBPermissions.PreserveOwnerPermission == (preserveSMBPermissions & PreserveSMBPermissions.PreserveOwnerPermission))
+                securityInfo |= (uint)NativeMethods.SECURITY_INFORMATION.OWNER_SECURITY_INFORMATION;
+
+            if (PreserveSMBPermissions.PreserveGroupPermission == (preserveSMBPermissions & PreserveSMBPermissions.PreserveGroupPermission))
+                securityInfo |= (uint)NativeMethods.SECURITY_INFORMATION.GROUP_SECURITY_INFORMATION;
+
+            if (PreserveSMBPermissions.PreserveDACLPermission == (preserveSMBPermissions & PreserveSMBPermissions.PreserveDACLPermission))
+                securityInfo |= (uint)NativeMethods.SECURITY_INFORMATION.DACL_SECURITY_INFORMATION;
+
+            if (PreserveSMBPermissions.PreserveSACLPermission == (preserveSMBPermissions & PreserveSMBPermissions.PreserveSACLPermission))
+                securityInfo |= (uint)NativeMethods.SECURITY_INFORMATION.SACL_SECURITY_INFORMATION;
+
+            return (NativeMethods.SECURITY_INFORMATION)(securityInfo);
+        }
+
+        private static string GetUserName()
+        {
+            StringBuilder userNameBuffer = new StringBuilder(64);
+            int nSize = 64;
+            if (!NativeMethods.GetUserName(userNameBuffer, ref nSize))
+            {
+                if (Marshal.GetLastWin32Error() == NativeMethods.ERROR_INSUFFICIENT_BUFFER)
+                {
+                    userNameBuffer.EnsureCapacity(nSize);
+
+                    if (!NativeMethods.GetUserName(userNameBuffer, ref nSize))
+                    {
+                        throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+                    }
+                }
+                else
+                {
+                    throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+            }
+
+            return userNameBuffer.ToString();
+        }
+
+        private static string GetPortableSDDL(string sddl, string domainSid)
+        {
+            StringBuilder portableSddl = new StringBuilder();
+
+            // Map of well known domain relative idenifiers to their full SID
+            Dictionary<string, string> domainRelativeIdentifiersMap = new Dictionary<string, string>();
+
+            domainRelativeIdentifiersMap.Add("LA", domainSid + "-500");
+            domainRelativeIdentifiersMap.Add("LG", domainSid + "-501");
+            domainRelativeIdentifiersMap.Add("CA", domainSid + "-517");
+            domainRelativeIdentifiersMap.Add("DA", domainSid + "-512");
+            domainRelativeIdentifiersMap.Add("DD", domainSid + "-516");
+            domainRelativeIdentifiersMap.Add("DU", domainSid + "-513");
+            domainRelativeIdentifiersMap.Add("DG", domainSid + "-514");
+            domainRelativeIdentifiersMap.Add("DC", domainSid + "-515");
+            domainRelativeIdentifiersMap.Add("SA", domainSid + "-518");
+            domainRelativeIdentifiersMap.Add("EA", domainSid + "-519");
+            domainRelativeIdentifiersMap.Add("PA", domainSid + "-520");
+            domainRelativeIdentifiersMap.Add("RS", domainSid + "-553");
+            domainRelativeIdentifiersMap.Add("ED", domainSid + "-498");
+            domainRelativeIdentifiersMap.Add("RO", domainSid + "-521");
+
+            // Parse the sddl and convert into portable format i.e. replace each detected RID into full SID
+            {
+                int ownerIndex = sddl.IndexOf("O:", StringComparison.Ordinal);
+                int groupIndex = sddl.IndexOf("G:", StringComparison.Ordinal);
+                int daclIndex = sddl.IndexOf("D:", StringComparison.Ordinal);
+                int saclIndex = sddl.IndexOf("S:", StringComparison.Ordinal);
+
+                List<int> indexes = new List<int>();
+
+                if (ownerIndex != -1)
+                {
+                    indexes.Add(ownerIndex);
+                }
+
+                if (groupIndex != -1)
+                {
+                    indexes.Add(groupIndex);
+                }
+
+                if (daclIndex != -1)
+                {
+                    indexes.Add(daclIndex);
+                }
+
+                if (saclIndex != -1)
+                {
+                    indexes.Add(saclIndex);
+                }
+
+                indexes.Add(sddl.Length);
+
+                indexes.Sort();
+
+                for (int index = 0; index < indexes.Count - 1; index++)
+                {
+                    int beginIndex = indexes[index];
+                    int endIndex = indexes[index + 1];
+
+                    if ((beginIndex == ownerIndex) ||
+                        (beginIndex == groupIndex))
+                    {
+                        // Fix owner / group
+                        // Owner and Group have the same format
+                        bool sddlCopied = false;
+
+                        foreach (var keypair in domainRelativeIdentifiersMap)
+                        {
+                            int ridIndex = sddl.IndexOf(keypair.Key, beginIndex, StringComparison.Ordinal);
+
+                            if ((ridIndex != -1) && (ridIndex < endIndex))
+                            {
+                                sddlCopied = true;
+                                portableSddl.Append(sddl, beginIndex, ridIndex - beginIndex);
+                                portableSddl.Append(keypair.Value);
+
+                                beginIndex = ridIndex + keypair.Key.Length;
+                            }
+                        }
+
+                        if (!sddlCopied)
+                        {
+                            portableSddl.Append(sddl, beginIndex, endIndex - beginIndex);
+                        }
+                    }
+                    else if ((beginIndex == daclIndex) ||
+                        (beginIndex == saclIndex))
+                    {
+                        // Fix dacl / sacl
+                        // DACL and SACL have the same format
+                        // Each acl format is: ace_type;ace_flags;rights;object_guid;inherit_object_guid;account_sid;(resource_attribute)
+                        int aclStartIndex = sddl.IndexOf('(', beginIndex);
+                        bool sddlCopied = false;
+
+                        if ((aclStartIndex != -1) && (aclStartIndex < endIndex))
+                        {
+                            portableSddl.Append(sddl, beginIndex, aclStartIndex - beginIndex);
+                        }
+
+                        while ((aclStartIndex != -1) && (aclStartIndex < endIndex))
+                        {
+                            sddlCopied = false;
+
+                            int aclEndIndex = sddl.IndexOf(')', aclStartIndex + 1);
+
+                            if (aclStartIndex == -1)
+                            {
+                                Console.Error.WriteLine("Invalid SDDL");
+                                return "";
+                            }
+
+                            // Fix the account Sid if it have domain RID
+                            // format is: ace_type;ace_flags;rights;object_guid;inherit_object_guid;account_sid;(resource_attribute) 
+                            int accountSidStart = sddl.IndexOf(';', aclStartIndex + 1);
+                            accountSidStart = sddl.IndexOf(';', accountSidStart + 1);
+                            accountSidStart = sddl.IndexOf(';', accountSidStart + 1);
+                            accountSidStart = sddl.IndexOf(';', accountSidStart + 1);
+                            accountSidStart = sddl.IndexOf(';', accountSidStart + 1);
+
+                            portableSddl.Append(sddl, aclStartIndex, accountSidStart - aclStartIndex);
+
+                            foreach (var keypair in domainRelativeIdentifiersMap)
+                            {
+                                int ridIndex = sddl.IndexOf(keypair.Key, accountSidStart, StringComparison.Ordinal);
+
+                                if ((ridIndex != -1) && (ridIndex < aclEndIndex))
+                                {
+                                    sddlCopied = true;
+                                    portableSddl.Append(sddl, accountSidStart, ridIndex - accountSidStart);
+                                    portableSddl.Append(keypair.Value);
+                                    portableSddl.Append(sddl, ridIndex + keypair.Key.Length, aclEndIndex - (ridIndex + keypair.Key.Length) + 1);
+                                }
+                            }
+
+                            if (!sddlCopied)
+                            {
+                                sddlCopied = true;
+                                portableSddl.Append(sddl, accountSidStart, (aclEndIndex - accountSidStart) + 1);
+                            }
+
+                            aclStartIndex = sddl.IndexOf('(', aclEndIndex);
+                        }
+
+                        if (!sddlCopied)
+                        {
+                            portableSddl.Append(sddl, beginIndex, endIndex - beginIndex);
+                        }
+                    }
+                }
+            }
+
+            return portableSddl.ToString();
+        }
+
+        private static string GetFileSDDL(
+            string filePath,
+            NativeMethods.SECURITY_INFORMATION securityInfo)
+        {
+            // Note: to get the SACL, special permissions are needed. Refer https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-getsecurityinfo
+            IntPtr pZero = IntPtr.Zero;
+            IntPtr pSid = pZero;
+            IntPtr psd = pZero;
+
+            uint errorReturn = NativeMethods.GetNamedSecurityInfoW(
+                filePath,
+                NativeMethods.SE_OBJECT_TYPE.SE_FILE_OBJECT,
+                securityInfo,
+                out pSid, out pZero, out pZero, out pZero, out psd);
+
+            if (errorReturn == NativeMethods.ERROR_PRIVILEGE_NOT_HELD)
+            {
+                throw new TransferException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.PrivilegeRequiredException,
+                        "https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-getsecurityinfo"));
+            }
+            else if (errorReturn != 0)
+            {
+                throw new Win32Exception((int)errorReturn);
+            }
+
+            try
+            {
+                IntPtr sdString = IntPtr.Zero;
+                UIntPtr sd_string_size_ptr = new UIntPtr();
+                bool success = NativeMethods.ConvertSecurityDescriptorToStringSecurityDescriptor(psd, NativeMethods.SDDL_REVISION_1, securityInfo, out sdString, out sd_string_size_ptr);
+                try
+                {
+                    return Marshal.PtrToStringAuto(sdString);
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(sdString);
+                }
+            }
+            finally
+            {
+                NativeMethods.LocalFree(psd);
+            }
+        }
+
+        private static string GetDomainSid(string accountName)
+        {
+            uint sidLength = 0;
+            uint domainNameLength = 0;
+            byte[] sid = null;
+            StringBuilder domainName = new StringBuilder();
+            NativeMethods.SID_NAME_USE peUse;
+
+            // Query buffer size requirement by passing in NULL for Sid and ReferencedDomainName
+            if (!NativeMethods.LookupAccountName(null, // lpSystemName
+                                   accountName,
+                                   null,  // Sid
+                                   ref sidLength,
+                                   domainName,  // ReferencedDomainName
+                                   ref domainNameLength,
+                                   out peUse))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (errorCode != NativeMethods.ERROR_INSUFFICIENT_BUFFER)
+                {
+                    throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+
+                sid = new byte[sidLength];
+                domainName.EnsureCapacity((int)domainNameLength);
+
+                if (!NativeMethods.LookupAccountName(null,
+                               accountName,
+                               sid,
+                               ref sidLength,
+                               domainName,
+                               ref domainNameLength,
+                               out peUse))
+                {
+                    throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+            }
+            else
+            {
+                throw new TransferException("Unexpected LookupAccountName success");
+            }
+
+            // Get domain Sid from User Sid
+            uint domainSidLength = 0;
+            byte[] domainSid = null;
+            if (!NativeMethods.GetWindowsAccountDomainSid(sid, domainSid, ref domainSidLength))
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (errorCode != NativeMethods.ERROR_INSUFFICIENT_BUFFER)
+                {
+                    throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+
+                domainSid = new byte[domainSidLength];
+
+                if (!NativeMethods.GetWindowsAccountDomainSid(sid, domainSid, ref domainSidLength))
+                {
+                    throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+            }
+            else
+            {
+                throw new TransferException("Unexpected GetWindowsAccountDomainSid success");
+            }
+
+            // Get string corresponding to SID
+            IntPtr domainSidPtr;
+            if (!NativeMethods.ConvertSidToStringSid(domainSid, out domainSidPtr))
+            {
+                throw Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+            }
+
+            try
+            {
+                return Marshal.PtrToStringAuto(domainSidPtr);
+            }
+            finally
+            {
+                NativeMethods.LocalFree(domainSidPtr);
+            }
+        }
+    }
+}

--- a/lib/FileSecurityOperations.cs
+++ b/lib/FileSecurityOperations.cs
@@ -466,22 +466,23 @@ namespace Microsoft.Azure.Storage.DataMovement
             StringBuilder portableSddl = new StringBuilder();
 
             // Map of well known domain relative idenifiers to their full SID
-            Dictionary<string, string> domainRelativeIdentifiersMap = new Dictionary<string, string>();
-
-            domainRelativeIdentifiersMap.Add("LA", domainSid + "-500");
-            domainRelativeIdentifiersMap.Add("LG", domainSid + "-501");
-            domainRelativeIdentifiersMap.Add("CA", domainSid + "-517");
-            domainRelativeIdentifiersMap.Add("DA", domainSid + "-512");
-            domainRelativeIdentifiersMap.Add("DD", domainSid + "-516");
-            domainRelativeIdentifiersMap.Add("DU", domainSid + "-513");
-            domainRelativeIdentifiersMap.Add("DG", domainSid + "-514");
-            domainRelativeIdentifiersMap.Add("DC", domainSid + "-515");
-            domainRelativeIdentifiersMap.Add("SA", domainSid + "-518");
-            domainRelativeIdentifiersMap.Add("EA", domainSid + "-519");
-            domainRelativeIdentifiersMap.Add("PA", domainSid + "-520");
-            domainRelativeIdentifiersMap.Add("RS", domainSid + "-553");
-            domainRelativeIdentifiersMap.Add("ED", domainSid + "-498");
-            domainRelativeIdentifiersMap.Add("RO", domainSid + "-521");
+            Dictionary<string, string> domainRelativeIdentifiersMap = new Dictionary<string, string>
+            {
+                { "LA", domainSid + "-500" },
+                { "LG", domainSid + "-501" },
+                { "CA", domainSid + "-517" },
+                { "DA", domainSid + "-512" },
+                { "DD", domainSid + "-516" },
+                { "DU", domainSid + "-513" },
+                { "DG", domainSid + "-514" },
+                { "DC", domainSid + "-515" },
+                { "SA", domainSid + "-518" },
+                { "EA", domainSid + "-519" },
+                { "PA", domainSid + "-520" },
+                { "RS", domainSid + "-553" },
+                { "ED", domainSid + "-498" },
+                { "RO", domainSid + "-521" }
+            };
 
             // Parse the sddl and convert into portable format i.e. replace each detected RID into full SID
             {

--- a/lib/PreserveSMBPermissions.cs
+++ b/lib/PreserveSMBPermissions.cs
@@ -1,0 +1,53 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="PreserveSMBPermissions.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Storage.DataMovement
+{
+    using System;
+
+    /// <summary>
+    /// Enum to indicate what permission would be perserved DataMovement Library.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SMB")]
+    [Flags]
+    public enum PreserveSMBPermissions : int
+    {
+        /// <summary>
+        /// Indicate to not preserve any permission
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// To preserve Owner permission.
+        /// In some cases, it requires to enable SeRestorePrivilege to set owner info to local file. 
+        /// See <c>https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setnamedsecurityinfow</c> for details.
+        /// To set owner permission to local file during downloading, the process needs to run with an account who has been assigned
+        /// the privilege, for example run the process with administrator account.
+        /// </summary>
+        PreserveOwnerPermission = 0x00000001,
+
+        /// <summary>
+        /// To preserve Group permission.
+        /// </summary>
+        PreserveGroupPermission = 0x00000002,
+
+        /// <summary>
+        /// To preserve DACL permission.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "DACL")]
+        PreserveDACLPermission = 0x00000004,
+
+        /// <summary>
+        /// To preserve SACL permission.
+        /// It requires to enable SeSecurityPrivilege to get or set SACL from or to local file.
+        /// See <c>https://docs.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setnamedsecurityinfow</c> for details.
+        /// To get or set owner permission from or to local file, the process needs to run with an account who has been assigned
+        /// the privilege, for example run the process with administrator account.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SACL")]
+        PreserveSACLPermission = 0x00000008
+    }
+}

--- a/lib/PreserveSMBPermissions.cs
+++ b/lib/PreserveSMBPermissions.cs
@@ -27,18 +27,18 @@ namespace Microsoft.Azure.Storage.DataMovement
         /// To set owner permission to local file during downloading, the process needs to run with an account who has been assigned
         /// the privilege, for example run the process with administrator account.
         /// </summary>
-        PreserveOwnerPermission = 0x00000001,
+        Owner = 0x00000001,
 
         /// <summary>
         /// To preserve Group permission.
         /// </summary>
-        PreserveGroupPermission = 0x00000002,
+        Group = 0x00000002,
 
         /// <summary>
         /// To preserve DACL permission.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "DACL")]
-        PreserveDACLPermission = 0x00000004,
+        DACL = 0x00000004,
 
         /// <summary>
         /// To preserve SACL permission.
@@ -48,6 +48,6 @@ namespace Microsoft.Azure.Storage.DataMovement
         /// the privilege, for example run the process with administrator account.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SACL")]
-        PreserveSACLPermission = 0x00000008
+        SACL = 0x00000008
     }
 }

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -270,6 +270,15 @@ namespace Microsoft.Azure.Storage.DataMovement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to enable {0}, please run the process with an account with the specific privilege assigned, for example run it with administrator..
+        /// </summary>
+        internal static string FailedToEnablePrivilegeException {
+            get {
+                return ResourceManager.GetString("FailedToEnablePrivilegeException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to enumerate directory {0} with file pattern {1}..
         /// </summary>
         internal static string FailedToEnumerateDirectory {
@@ -419,6 +428,15 @@ namespace Microsoft.Azure.Storage.DataMovement {
         internal static string PathNotFound {
             get {
                 return ResourceManager.GetString("PathNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;A required privilege is not held. Please run the process with the privilege assigned, for example run it with administrator. Reference to {0} for details..
+        /// </summary>
+        internal static string PrivilegeRequiredException {
+            get {
+                return ResourceManager.GetString("PrivilegeRequiredException", resourceCulture);
             }
         }
         

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Azure.Storage.DataMovement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to enable {0}, please run the process with an account with the specific privilege assigned, for example run it with administrator..
+        ///   Looks up a localized string similar to Failed to enable {0}, please run the process with an account with privilege &apos;{0}&apos; assigned, for example run it with administrator..
         /// </summary>
         internal static string FailedToEnablePrivilegeException {
             get {
@@ -432,7 +432,7 @@ namespace Microsoft.Azure.Storage.DataMovement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;A required privilege is not held. Please run the process with the privilege assigned, for example run it with administrator. Reference to {0} for details..
+        ///   Looks up a localized string similar to &quot;Lack of required privilege(s). Please run the process with privilege(s) &apos;{0}&apos; assigned, for example run it with administrator..
         /// </summary>
         internal static string PrivilegeRequiredException {
             get {

--- a/lib/Resources.Designer.cs
+++ b/lib/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Storage.DataMovement {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Storage.DataMovement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File size {0} is larger than cloud file maximum size {1} bytes..
+        ///   Looks up a localized string similar to The file size exceeds the maximum permissible limit..
         /// </summary>
         internal static string CloudFileSizeTooLargeException {
             get {

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -190,6 +190,10 @@ MD5 in property: {2}</value>
     <value>Failed to open file {0}: {1}.</value>
     <comment>{0} is file name, {1} is detailed error message.</comment>
   </data>
+  <data name="FailedToEnablePrivilegeException" xml:space="preserve">
+    <value>Failed to enable {0}, please run the process with an account with the specific privilege assigned, for example run it with administrator.</value>
+    <comment>{0} is privilege string.</comment>
+  </data>
   <data name="FilePathTooLong" xml:space="preserve">
     <value>The specified path, file name, or both are too long for file: "{0}"</value>
     <comment>{0} is the relative path.</comment>
@@ -226,6 +230,10 @@ MD5 in property: {2}</value>
   <data name="PathNotFound" xml:space="preserve">
     <value>Cannot find the path '{0}'.</value>
     <comment>{0} is the path.</comment>
+  </data>
+  <data name="PrivilegeRequiredException" xml:space="preserve">
+    <value>"A required privilege is not held. Please run the process with the privilege assigned, for example run it with administrator. Reference to {0} for details.</value>
+    <comment>{0} is the document link.</comment>
   </data>
   <data name="ProvideExactlyOneOfThreeParameters" xml:space="preserve">
     <value>Exactly one of these parameters must be provided: {0}, {1}, {2}.</value>

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -191,7 +191,7 @@ MD5 in property: {2}</value>
     <comment>{0} is file name, {1} is detailed error message.</comment>
   </data>
   <data name="FailedToEnablePrivilegeException" xml:space="preserve">
-    <value>Failed to enable {0}, please run the process with an account with the specific privilege assigned, for example run it with administrator.</value>
+    <value>Failed to enable {0}, please run the process with an account with privilege '{0}' assigned, for example run it with administrator.</value>
     <comment>{0} is privilege string.</comment>
   </data>
   <data name="FilePathTooLong" xml:space="preserve">
@@ -232,8 +232,8 @@ MD5 in property: {2}</value>
     <comment>{0} is the path.</comment>
   </data>
   <data name="PrivilegeRequiredException" xml:space="preserve">
-    <value>"A required privilege is not held. Please run the process with the privilege assigned, for example run it with administrator. Reference to {0} for details.</value>
-    <comment>{0} is the document link.</comment>
+    <value>"Lack of required privilege(s). Please run the process with privilege(s) '{0}' assigned, for example run it with administrator.</value>
+    <comment>{0} is name of privilege</comment>
   </data>
   <data name="ProvideExactlyOneOfThreeParameters" xml:space="preserve">
     <value>Exactly one of these parameters must be provided: {0}, {1}, {2}.</value>

--- a/lib/Resources.resx
+++ b/lib/Resources.resx
@@ -138,8 +138,7 @@
     <value>The TransferLocation cannot be serialized when it represents a stream location.</value>
   </data>
   <data name="CloudFileSizeTooLargeException" xml:space="preserve">
-    <value>File size {0} is larger than cloud file maximum size {1} bytes.</value>
-    <comment>{0} is file size. {1} is the size limit of the destination.</comment>
+    <value>The file size exceeds the maximum permissible limit.</value>
   </data>
   <data name="CanOnlyCopyToFileOrBlobException" xml:space="preserve">
     <value>Destination of asynchronous copying must be File Storage or Blob Storage.</value>

--- a/lib/TestHook/TestHookCallbacks.cs
+++ b/lib/TestHook/TestHookCallbacks.cs
@@ -12,6 +12,15 @@ namespace Microsoft.Azure.Storage.DataMovement
     {
         public static Action<string, FileAttributes> SetFileAttributesCallback;
         public static Func<string, FileAttributes> GetFileAttributesCallback;
+
+        public static Action<string, string, PreserveSMBPermissions> SetFilePermissionsCallback;
+        public static Func<string, PreserveSMBPermissions, string> GetFilePermissionsCallback;
+
+        public static bool UnderTesting
+        {
+            get;
+            set;
+        }
     }
 #endif
 }

--- a/lib/TransferControllers/TransferControllerBase.cs
+++ b/lib/TransferControllers/TransferControllerBase.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
 
         protected async Task<bool> CheckShouldTransfer()
         {
-            DirectoryTransferContext directoryTransferContext = this.TransferContext as DirectoryTransferContext;
+            var directoryTransferContext = this.TransferContext as DirectoryTransferContext;
             if ((null != directoryTransferContext)
                 && (null != directoryTransferContext.ShouldTransferCallbackAsync))
             {

--- a/lib/TransferControllers/TransferReaders/CloudFileReader.cs
+++ b/lib/TransferControllers/TransferReaders/CloudFileReader.cs
@@ -56,8 +56,7 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
 
             this.SharedTransferData.DisableContentMD5Validation =
                 null != this.sourceLocation.FileRequestOptions ?
-                this.sourceLocation.FileRequestOptions.DisableContentMD5Validation.HasValue ?
-                this.sourceLocation.FileRequestOptions.DisableContentMD5Validation.Value : false : false;
+                this.sourceLocation.FileRequestOptions.DisableContentMD5Validation ?? false : false;
 
             var transfer = this.SharedTransferData.TransferJob.Transfer;
 
@@ -75,7 +74,8 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
 
                     if (null != sddlCache)
                     {
-                        string portableSDDL = sddlCache.GetValue(this.cloudFile.Properties.FilePermissionKey);
+                        string portableSDDL = null;
+                        sddlCache.TryGetValue(this.cloudFile.Properties.FilePermissionKey, out portableSDDL);
 
                         if (null == portableSDDL)
                         {
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
                                 Utils.GenerateOperationContext(this.Controller.TransferContext),
                                 this.CancellationToken).ConfigureAwait(false);
 
-                            sddlCache.AddValue(this.cloudFile.Properties.FilePermissionKey, portableSDDL);
+                            sddlCache.TryAddValue(this.cloudFile.Properties.FilePermissionKey, portableSDDL);
                         }
 
                         this.SharedTransferData.Attributes.PortableSDDL = portableSDDL;

--- a/lib/TransferControllers/TransferReaders/StreamedReader.cs
+++ b/lib/TransferControllers/TransferReaders/StreamedReader.cs
@@ -525,6 +525,14 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
                         }
                     }
 
+                    if (PreserveSMBPermissions.None != this.transferJob.Transfer.PreserveSMBPermissions)
+                    {
+                        if (!string.IsNullOrEmpty(this.filePath))
+                        {
+                            attributes.PortableSDDL = FileSecurityOperations.GetFilePortableSDDL(filePath, this.transferJob.Transfer.PreserveSMBPermissions);
+                        }
+                    }
+
                     this.SharedTransferData.Attributes = attributes;
                 }
             }

--- a/lib/TransferControllers/TransferWriters/CloudFileWriter.cs
+++ b/lib/TransferControllers/TransferWriters/CloudFileWriter.cs
@@ -128,13 +128,13 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
             if ((PreserveSMBPermissions.None != this.TransferJob.Transfer.PreserveSMBPermissions)
                 && !string.IsNullOrEmpty(this.SharedTransferData.Attributes.PortableSDDL))
             {
-                if (this.SharedTransferData.Attributes.PortableSDDL.Length >= 8 * 1024)
+                if (this.SharedTransferData.Attributes.PortableSDDL.Length >= Constants.MaxSDDLLengthInProperties)
                 {
                     string permissionKey = null;
                     var sddlCache = this.TransferJob.Transfer.SDDLCache;
                     if (null != sddlCache)
                     {
-                        permissionKey = sddlCache.GetValue(this.SharedTransferData.Attributes.PortableSDDL);
+                        sddlCache.TryGetValue(this.SharedTransferData.Attributes.PortableSDDL, out permissionKey);
 
                         if (null == permissionKey)
                         {
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
                                 operationContext,
                                 this.CancellationToken).ConfigureAwait(false);
 
-                            sddlCache.AddValue(this.SharedTransferData.Attributes.PortableSDDL, permissionKey);
+                            sddlCache.TryAddValue(this.SharedTransferData.Attributes.PortableSDDL, permissionKey);
                         }
                     }
                     else

--- a/lib/TransferControllers/TransferWriters/StreamedWriter.cs
+++ b/lib/TransferControllers/TransferWriters/StreamedWriter.cs
@@ -390,6 +390,18 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
                     }
                 }
 
+                if ((PreserveSMBPermissions.None != this.TransferJob.Transfer.PreserveSMBPermissions)
+                    && (!string.IsNullOrEmpty(this.SharedTransferData.Attributes.PortableSDDL)))
+                {
+                    if (!string.IsNullOrEmpty(this.filePath))
+                    {
+                        FileSecurityOperations.SetFileSecurity(
+                            this.filePath,
+                            this.SharedTransferData.Attributes.PortableSDDL,
+                            this.TransferJob.Transfer.PreserveSMBPermissions);
+                    }
+                }
+
                 this.NotifyFinished(ex);
                 this.state = State.Finished;
             }

--- a/lib/TransferJobs/DirectoryTransfer.cs
+++ b/lib/TransferJobs/DirectoryTransfer.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Storage.DataMovement
 
             set
             {
-                DirectoryTransferContext tempValue = value as DirectoryTransferContext;
+                var tempValue = value as DirectoryTransferContext;
 
                 if (tempValue == null)
                 {
@@ -440,6 +440,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             var transferMethod = IsDummyCopy(entry) ? TransferMethod.DummyCopy : this.TransferMethod;
             SingleObjectTransfer transfer = new SingleObjectTransfer(sourceLocation, destLocation, transferMethod);
             transfer.PreserveSMBAttributes = this.PreserveSMBAttributes;
+            transfer.PreserveSMBPermissions = this.PreserveSMBPermissions;
             transfer.Context = this.Context;
             return transfer;
         }
@@ -481,6 +482,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             DirectoryTransfer.UpdateCredentials(this.Source, transfer.Source);
             DirectoryTransfer.UpdateCredentials(this.Destination, transfer.Destination);
             transfer.PreserveSMBAttributes = this.PreserveSMBAttributes;
+            transfer.PreserveSMBPermissions = this.PreserveSMBPermissions;
         }
 
         private static void UpdateCredentials(TransferLocation dirLocation, TransferLocation subLocation)

--- a/lib/TransferJobs/HierarchyDirectoryTransfer.cs
+++ b/lib/TransferJobs/HierarchyDirectoryTransfer.cs
@@ -778,13 +778,19 @@ namespace Microsoft.Azure.Storage.DataMovement
                     {
                         this.enumerateException = ex;
                     }
+                    else if ((null != ex.InnerException)
+                        && (ex.InnerException is OperationCanceledException))
+                    {
+                        // Ingore this exception, there's other place reporting such kind of exception when cancellation is triggered.
+                        errorHappened = true;
+                    }
                     else
                     {
                         this.enumerateException = new TransferException(
                             TransferErrorCode.FailToEnumerateDirectory,
                             string.Format(CultureInfo.CurrentCulture,
                                 Resources.EnumerateDirectoryException,
-                                this.Destination.Instance.ConvertToString()), 
+                                this.Destination.Instance.ConvertToString()),
                             ex);
                     }
 

--- a/lib/TransferJobs/HierarchyDirectoryTransfer.cs
+++ b/lib/TransferJobs/HierarchyDirectoryTransfer.cs
@@ -220,6 +220,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             // Constructors and field initializers are not called by DCS, so initialize things here
             progressUpdateLock = new ReaderWriterLockSlim();
             continuationTokenLock = new object();
+            this.azureFileDirectorySDDLCache = new AzureFileDirectorySDDLCache();
 
             if (!IsStreamJournal)
             {

--- a/lib/TransferJobs/HierarchyDirectoryTransfer.cs
+++ b/lib/TransferJobs/HierarchyDirectoryTransfer.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Azure.Storage.DataMovement
 
         private DirectoryListingScheduler directoryListingScheduler = null;
 
+        private AzureFileDirectorySDDLCache azureFileDirectorySDDLCache = new AzureFileDirectorySDDLCache(); 
+
 #if !BINARY_SERIALIZATION
         [DataMember]
 #endif
@@ -280,6 +282,14 @@ namespace Microsoft.Azure.Storage.DataMovement
             }
         }
 
+        public AzureFileDirectorySDDLCache SDDLCache
+        {
+            get
+            {
+                return this.azureFileDirectorySDDLCache;
+            }
+        }
+
         public string SearchPattern
         {
             get;
@@ -345,6 +355,12 @@ namespace Microsoft.Azure.Storage.DataMovement
                 {
                     this.directoryListingScheduler.Dispose();
                     this.directoryListingScheduler = null;
+                }
+
+                if (null != this.azureFileDirectorySDDLCache)
+                {
+                    this.azureFileDirectorySDDLCache.Dispose();
+                    this.azureFileDirectorySDDLCache = null;
                 }
             }
 

--- a/lib/TransferJobs/SingleObjectTransfer.cs
+++ b/lib/TransferJobs/SingleObjectTransfer.cs
@@ -166,6 +166,12 @@ namespace Microsoft.Azure.Storage.DataMovement
             }
         }
 
+        public AzureFileDirectorySDDLCache SDDLCache
+        {
+            get;
+            set;
+        }
+
         /// <summary>
         /// Creates a copy of current transfer object.
         /// </summary>

--- a/lib/TransferJobs/Transfer.cs
+++ b/lib/TransferJobs/Transfer.cs
@@ -250,6 +250,10 @@ namespace Microsoft.Azure.Storage.DataMovement
             set;
         }
 
+        /// <summary>
+        /// Gets or sets a value that indicates whether to preserve SMB permissions during transferring.
+        /// Preserving SMB permissions is only supported on Windows.
+        /// </summary>
         public PreserveSMBPermissions PreserveSMBPermissions
         {
             get;

--- a/lib/TransferJobs/Transfer.cs
+++ b/lib/TransferJobs/Transfer.cs
@@ -250,6 +250,12 @@ namespace Microsoft.Azure.Storage.DataMovement
             set;
         }
 
+        public PreserveSMBPermissions PreserveSMBPermissions
+        {
+            get;
+            set;
+        }
+
         /// <summary>
         /// Gets the progress tracker for this transfer.
         /// </summary>

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             if (options != null)
             {
                 destLocation.AccessCondition = options.DestinationAccessCondition;
-                FileSecurityOperations.BeginTransferJob(options.PreserveSMBPermissions, false);
+                FileSecurityOperations.EnableRequiredPrivileges(options.PreserveSMBPermissions, false);
             }
 
             try
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             {
                 if (options != null)
                 {
-                    FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, false);
+                    FileSecurityOperations.DisablePrivileges(options.PreserveSMBPermissions, false);
                 }
             }
         }
@@ -377,7 +377,7 @@ namespace Microsoft.Azure.Storage.DataMovement
 
             if (null != options)
             {
-                FileSecurityOperations.BeginTransferJob(options.PreserveSMBPermissions, false);
+                FileSecurityOperations.EnableRequiredPrivileges(options.PreserveSMBPermissions, false);
             }
 
             try
@@ -388,7 +388,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             {
                 if (options != null)
                 {
-                    FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, false);
+                    FileSecurityOperations.DisablePrivileges(options.PreserveSMBPermissions, false);
                 }
             }
         }
@@ -466,8 +466,6 @@ namespace Microsoft.Azure.Storage.DataMovement
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
                 sourceLocation.BlobRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-
-                //TODO handle unsupported options
             }
 
             return DownloadInternalAsync(sourceLocation, destLocation, options, context, cancellationToken);
@@ -519,7 +517,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             {
                 sourceLocation.AccessCondition = options.SourceAccessCondition;
                 sourceLocation.FileRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-                FileSecurityOperations.BeginTransferJob(options.PreserveSMBPermissions, true);
+                FileSecurityOperations.EnableRequiredPrivileges(options.PreserveSMBPermissions, true);
             }
 
             try
@@ -530,7 +528,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             {
                 if (options != null)
                 {
-                    FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, true);
+                    FileSecurityOperations.DisablePrivileges(options.PreserveSMBPermissions, true);
                 }
             }
         }
@@ -663,7 +661,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             {
                 TransferManager.CheckSearchPatternOfAzureFileSource(options);                                
                 sourceLocation.FileRequestOptions.DisableContentMD5Validation = options.DisableContentMD5Validation;
-                FileSecurityOperations.BeginTransferJob(options.PreserveSMBPermissions, true);
+                FileSecurityOperations.EnableRequiredPrivileges(options.PreserveSMBPermissions, true);
             }
 
             try
@@ -674,7 +672,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             {
                 if (options != null)
                 {
-                    FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, true);
+                    FileSecurityOperations.DisablePrivileges(options.PreserveSMBPermissions, true);
                 }
             }
         }

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -386,7 +386,10 @@ namespace Microsoft.Azure.Storage.DataMovement
             }
             finally
             {
-                FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, false);
+                if (options != null)
+                {
+                    FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, false);
+                }
             }
         }
 
@@ -525,7 +528,10 @@ namespace Microsoft.Azure.Storage.DataMovement
             }
             finally
             {
-                FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, true);
+                if (options != null)
+                {
+                    FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, true);
+                }
             }
         }
 
@@ -666,7 +672,10 @@ namespace Microsoft.Azure.Storage.DataMovement
             }
             finally
             {
-                FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, true);
+                if (options != null)
+                {
+                    FileSecurityOperations.EndTransferJob(options.PreserveSMBPermissions, true);
+                }
             }
         }
 
@@ -1610,7 +1619,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             Transfer transfer = GetOrCreateSingleObjectTransfer(sourceLocation, destLocation, TransferMethod.SyncCopy, context);
 
             if ((null != uploadOptions)
-                && (destLocation.Type == TransferLocationType.AzureFileDirectory))
+                && (destLocation.Type == TransferLocationType.AzureFile))
             {
                 transfer.PreserveSMBAttributes = uploadOptions.PreserveSMBAttributes;
                 transfer.PreserveSMBPermissions = uploadOptions.PreserveSMBPermissions;

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -632,7 +632,7 @@ namespace Microsoft.Azure.Storage.DataMovement
         /// </summary>
         /// <param name="sourceFileDir">The <see cref="CloudFileDirectory"/> that is the source Azure file directory.</param>
         /// <param name="destPath">Path to the destination directory</param>
-        /// <param name="options">A <see cref="DownloadOptions"/> object that specifies additional options for the operation.</param>
+        /// <param name="options">A <see cref="DownloadDirectoryOptions"/> object that specifies additional options for the operation.</param>
         /// <param name="context">A <see cref="DirectoryTransferContext"/> object that represents the context for the current operation.</param>
         /// <returns>A <see cref="Task{T}"/> object of type <see cref="TransferStatus"/> that represents the asynchronous operation.</returns>
         public static Task<TransferStatus> DownloadDirectoryAsync(CloudFileDirectory sourceFileDir, string destPath, DownloadDirectoryOptions options, DirectoryTransferContext context)
@@ -645,7 +645,7 @@ namespace Microsoft.Azure.Storage.DataMovement
         /// </summary>
         /// <param name="sourceFileDir">The <see cref="CloudFileDirectory"/> that is the source Azure file directory.</param>
         /// <param name="destPath">Path to the destination directory</param>
-        /// <param name="options">A <see cref="DownloadOptions"/> object that specifies additional options for the operation.</param>
+        /// <param name="options">A <see cref="DownloadDirectoryOptions"/> object that specifies additional options for the operation.</param>
         /// <param name="context">A <see cref="DirectoryTransferContext"/> object that represents the context for the current operation.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> object to observe while waiting for a task to complete.</param>
         /// <returns>A <see cref="Task{T}"/> object of type <see cref="TransferStatus"/> that represents the asynchronous operation.</returns>

--- a/lib/TransferOptions/DownloadDirectoryOptions.cs
+++ b/lib/TransferOptions/DownloadDirectoryOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Storage.DataMovement
     public sealed class DownloadDirectoryOptions : DirectoryOptions
     {
         private bool preserveSMBAttributes = false;
+        private PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.None;
         private char delimiter = '/';
 
         /// <summary>
@@ -82,6 +83,30 @@ namespace Microsoft.Azure.Storage.DataMovement
 #else
                 this.preserveSMBAttributes = value;
 #endif
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether to preserve SMB permissions during downloading.
+        /// Preserving SMB permissions is only supported on Windows.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SMB")]
+        public PreserveSMBPermissions PreserveSMBPermissions
+        {
+            get
+            {
+                return this.preserveSMBPermissions;
+            }
+
+            set
+            {
+#if DOTNET5_4
+                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+#endif
+                this.preserveSMBPermissions = value;
             }
         }
     }

--- a/lib/TransferOptions/DownloadDirectoryOptions.cs
+++ b/lib/TransferOptions/DownloadDirectoryOptions.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             set
             {
 #if DOTNET5_4
-                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                if ((value != PreserveSMBPermissions.None) && !Interop.CrossPlatformHelpers.IsWindows)
                 {
                     throw new PlatformNotSupportedException();
                 }

--- a/lib/TransferOptions/DownloadOptions.cs
+++ b/lib/TransferOptions/DownloadOptions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             set
             {
 #if DOTNET5_4
-                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                if ((value != PreserveSMBPermissions.None) && !Interop.CrossPlatformHelpers.IsWindows)
                 {
                     throw new PlatformNotSupportedException();
                 }

--- a/lib/TransferOptions/DownloadOptions.cs
+++ b/lib/TransferOptions/DownloadOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Storage.DataMovement
     public sealed class DownloadOptions
     {
         private bool preserveSMBAttributes = false;
+        private PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.None;
 
         /// <summary>
         /// Gets or sets an <see cref="AccessCondition"/> object that represents the access conditions for the source object. If <c>null</c>, no condition is used.
@@ -60,6 +61,30 @@ namespace Microsoft.Azure.Storage.DataMovement
 #else
                 this.preserveSMBAttributes = value;
 #endif
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether to preserve SMB permissions during downloading.
+        /// Preserving SMB permissions is only supported on Windows.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SMB")]
+        public PreserveSMBPermissions PreserveSMBPermissions
+        {
+            get
+            {
+                return this.preserveSMBPermissions;
+            }
+
+            set
+            {
+#if DOTNET5_4
+                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+#endif
+                this.preserveSMBPermissions = value;
             }
         }
     }

--- a/lib/TransferOptions/UploadDirectoryOptions.cs
+++ b/lib/TransferOptions/UploadDirectoryOptions.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Storage.DataMovement
         }
 
         /// <summary>
-        /// Gets or sets a value that indicates whether to preserve SMB permissions during downloading.
+        /// Gets or sets a value that indicates whether to preserve SMB permissions during uploading.
         /// Preserving SMB permissions is only supported on Windows.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SMB")]

--- a/lib/TransferOptions/UploadDirectoryOptions.cs
+++ b/lib/TransferOptions/UploadDirectoryOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Storage.DataMovement
     public sealed class UploadDirectoryOptions : DirectoryOptions
     {
         private bool preserveSMBAttributes = false;
+        private PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.None;
         private bool followSymlink = false;
 
         /// <summary>
@@ -77,6 +78,30 @@ namespace Microsoft.Azure.Storage.DataMovement
 #else
                 this.preserveSMBAttributes = value;
 #endif
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether to preserve SMB permissions during downloading.
+        /// Preserving SMB permissions is only supported on Windows.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SMB")]
+        public PreserveSMBPermissions PreserveSMBPermissions
+        {
+            get
+            {
+                return this.preserveSMBPermissions;
+            }
+
+            set
+            {
+#if DOTNET5_4
+                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+#endif
+                this.preserveSMBPermissions = value;
             }
         }
     }

--- a/lib/TransferOptions/UploadDirectoryOptions.cs
+++ b/lib/TransferOptions/UploadDirectoryOptions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             set
             {
 #if DOTNET5_4
-                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                if ((value != PreserveSMBPermissions.None) && !Interop.CrossPlatformHelpers.IsWindows)
                 {
                     throw new PlatformNotSupportedException();
                 }

--- a/lib/TransferOptions/UploadOptions.cs
+++ b/lib/TransferOptions/UploadOptions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Storage.DataMovement
     public sealed class UploadOptions
     {
         private bool preserveSMBAttributes = false;
+        private PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.None;
 
         /// <summary>
         /// Gets or sets an <see cref="AccessCondition"/> object that represents the access conditions for the destination object. If <c>null</c>, no condition is used.
@@ -53,6 +54,29 @@ namespace Microsoft.Azure.Storage.DataMovement
 #else
                 this.preserveSMBAttributes = value;
 #endif
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SMB")]
+        public PreserveSMBPermissions PreserveSMBPermissions
+        {
+            get
+            {
+                return this.preserveSMBPermissions;
+            }
+
+            set
+            {
+#if DOTNET5_4
+                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+#endif
+                this.preserveSMBPermissions = value;
             }
         }
     }

--- a/lib/TransferOptions/UploadOptions.cs
+++ b/lib/TransferOptions/UploadOptions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             set
             {
 #if DOTNET5_4
-                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                if ((value != PreserveSMBPermissions.None) && !Interop.CrossPlatformHelpers.IsWindows)
                 {
                     throw new PlatformNotSupportedException();
                 }

--- a/lib/TransferOptions/UploadOptions.cs
+++ b/lib/TransferOptions/UploadOptions.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Azure.Storage.DataMovement
         }
 
         /// <summary>
-        /// 
+        /// Gets or sets a value that indicates whether to preserve SMB permissions during uploading.
+        /// Preserving SMB permissions is only supported on Windows.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SMB")]
         public PreserveSMBPermissions PreserveSMBPermissions

--- a/lib/TransferStatusHelpers/Attributes.cs
+++ b/lib/TransferStatusHelpers/Attributes.cs
@@ -63,9 +63,14 @@ namespace Microsoft.Azure.Storage.DataMovement
         public DateTimeOffset? LastWriteTime { get; set; }
 
         /// <summary>
-        /// Gets or sets a value to indicate whether to overwrite all attribute on destination,
-        /// or keep its original value if it's not set.
+        /// Gets or sets the file attributes for azure file.
         /// </summary>
-        public bool OverWriteAll { get; set; }
+        public string PortableSDDL { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value to indicate whether to overwrite all attribute on destination,
+    /// or keep its original value if it's not set.
+    /// </summary>
+    public bool OverWriteAll { get; set; }
     }
 }

--- a/lib/packages.config
+++ b/lib/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.Blob" version="11.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.Common" version="11.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.File" version="11.1.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Blob" version="11.1.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="11.1.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.File" version="11.1.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />
   <package id="System.Dynamic.Runtime" version="4.0.0" targetFramework="net45" />

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -33,8 +33,8 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.0.4" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.1" />
+    <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -10,11 +10,13 @@
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50;portable-net45+win8</AssetTargetFallback>
     <RuntimeFrameworkVersion>2.0</RuntimeFrameworkVersion>
     <DebugType>portable</DebugType>
-    <DefineConstants>$(DefineConstants);DOTNET5_4;DNXCORE50;EXPECT_INTERNAL_WRAPPEDSTORAGEEXCEPTION;RUNTIME_INFORMATION</DefineConstants>
+    <DefineConstants>TRACE;DMLIB_TEST;DOTNET5_4;DNXCORE50;EXPECT_INTERNAL_WRAPPEDSTORAGEEXCEPTION;RUNTIME_INFORMATION</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\..\lib\LongPathFileStream.cs" Link="Framework\LongPathFileStream.cs" />
+    <Compile Include="..\..\lib\FileSecurityOperations.cs" Link="Framework\FileSecurityOperations.cs" />
+    <Compile Include="..\..\lib\FileSecurityNativeMethods.cs" Link="Framework\FileSecurityNativeMethods.cs" />
     <Compile Include="..\..\test\DMLibTest\Cases\*.cs">
       <Link>Cases\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>

--- a/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft.WindowsAzure.Storage.DataMovement Class Library</Description>
-    <Version>1.1.0.0</Version>
+    <Version>1.2.0.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
@@ -37,8 +37,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.0.4" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.1" />
+    <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.1" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0-beta2" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.6.0" />

--- a/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0-beta2" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.6.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
@@ -36,17 +36,17 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.Blob, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.11.1.0\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.Blob, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.11.1.1\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.Common, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.1.0\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.Common, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.1.1\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.1.1.0\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.1.2.0\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.File, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.File.11.1.0\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.File.11.1.1\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>

--- a/samples/DataMovementSamples/DataMovementSamples/packages.config
+++ b/samples/DataMovementSamples/DataMovementSamples/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.Blob" version="11.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.Common" version="11.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.File" version="11.1.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Blob" version="11.1.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="11.1.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="1.2.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.File" version="11.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />

--- a/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="1.2.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
+++ b/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
@@ -44,17 +44,17 @@
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.Blob, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.11.1.0\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.Blob, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Blob.11.1.1\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.Common, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.1.0\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.Common, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.1.1\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.1.1.0\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.1.2.0\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.File, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.File.11.1.0\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.File.11.1.1\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.1.8.0.0\lib\net35-full\Microsoft.WindowsAzure.Configuration.dll</HintPath>

--- a/samples/S3ToAzureSample/S3ToAzureSample/packages.config
+++ b/samples/S3ToAzureSample/S3ToAzureSample/packages.config
@@ -3,10 +3,10 @@
   <package id="AWSSDK.Core" version="3.1.1.0" targetFramework="net45" />
   <package id="AWSSDK.S3" version="3.1.2.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.Blob" version="11.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.Common" version="11.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.File" version="11.1.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Blob" version="11.1.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="11.1.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="1.2.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.File" version="11.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />

--- a/test/DMLibTest/Cases/FollowSymlinkTest.cs
+++ b/test/DMLibTest/Cases/FollowSymlinkTest.cs
@@ -305,7 +305,7 @@ namespace DMLibTest
 #endif
         }
 
-        /// n >= 40
+        /// n > 40
         /// Symlink_(n-1) -> Folder_n
         ///           -  File_(n-2)
         ///           -  Symlink_(n-2) -> Folder_(n-1)... ... Symlink_0 -> Folder_1
@@ -322,7 +322,7 @@ namespace DMLibTest
             }
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo("rootfolder");
 
-            int level = random.Next(40, 60);
+            int level = random.Next(41, 60);
 
             Test.Info($"Testing {level} levels of symlinked dirs");
 

--- a/test/DMLibTest/Cases/LongFilePathTest.cs
+++ b/test/DMLibTest/Cases/LongFilePathTest.cs
@@ -115,9 +115,9 @@ namespace DMLibTest.Cases
                 return;
             }
 
-            PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.PreserveOwnerPermission
-                        | PreserveSMBPermissions.PreserveGroupPermission
-                        | PreserveSMBPermissions.PreserveDACLPermission;
+            PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.Owner
+                        | PreserveSMBPermissions.Group
+                        | PreserveSMBPermissions.DACL;
 
             int fileSizeInKB = 1;
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo(GetDirectoryName(sourceDirectoryName, DMLibTestBase.FileName, pathLengthLimit));
@@ -154,7 +154,7 @@ namespace DMLibTest.Cases
             }
             string sampleSDDL = "O:S-1-5-21-2146773085-903363285-719344707-1375029G:S-1-5-21-2146773085-903363285-719344707-513D:(A;ID;FA;;;BA)(A;OICIIOID;GA;;;BA)(A;ID;FA;;;SY)(A;OICIIOID;GA;;;SY)(A;ID;0x1301bf;;;AU)(A;OICIIOID;SDGXGWGR;;;AU)(A;ID;0x1200a9;;;BU)(A;OICIIOID;GXGR;;;BU)";
 
-            PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.PreserveDACLPermission;
+            PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.DACL;
 
             int fileSizeInKB = 1;
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);

--- a/test/DMLibTest/Cases/SMBPropertiesTest.cs
+++ b/test/DMLibTest/Cases/SMBPropertiesTest.cs
@@ -688,9 +688,9 @@ namespace DMLibTest.Cases
             options.IsDirectoryTransfer = true;
 
             PreserveSMBPermissions preserveSMBPermissions =
-                PreserveSMBPermissions.PreserveOwnerPermission 
-                | PreserveSMBPermissions.PreserveGroupPermission 
-                | PreserveSMBPermissions.PreserveDACLPermission;
+                PreserveSMBPermissions.Owner 
+                | PreserveSMBPermissions.Group 
+                | PreserveSMBPermissions.DACL;
 
             options.TransferItemModifier = (fileNode, transferItem) =>
             {
@@ -749,9 +749,9 @@ namespace DMLibTest.Cases
             try
             {
                 PreserveSMBPermissions preserveSMBPermissions = 
-                    PreserveSMBPermissions.PreserveOwnerPermission 
-                    | PreserveSMBPermissions.PreserveGroupPermission 
-                    | PreserveSMBPermissions.PreserveDACLPermission;
+                    PreserveSMBPermissions.Owner 
+                    | PreserveSMBPermissions.Group 
+                    | PreserveSMBPermissions.DACL;
                 string sampleSDDL = "O:S-1-5-21-2146773085-903363285-719344707-1375029G:S-1-5-21-2146773085-903363285-719344707-513D:(A;ID;FA;;;BA)(A;OICIIOID;GA;;;BA)(A;ID;FA;;;SY)(A;OICIIOID;GA;;;SY)(A;ID;0x1301bf;;;AU)(A;OICIIOID;SDGXGWGR;;;AU)(A;ID;0x1200a9;;;BU)(A;OICIIOID;GXGR;;;BU)";
 
 #if DEBUG
@@ -818,9 +818,9 @@ namespace DMLibTest.Cases
             if (!CrossPlatformHelpers.IsWindows) return;
 
             PreserveSMBPermissions preserveSMBPermissions = 
-                PreserveSMBPermissions.PreserveOwnerPermission 
-                | PreserveSMBPermissions.PreserveGroupPermission 
-                | PreserveSMBPermissions.PreserveDACLPermission;
+                PreserveSMBPermissions.Owner 
+                | PreserveSMBPermissions.Group 
+                | PreserveSMBPermissions.DACL;
 
             string sampleSDDL = "O:S-1-5-21-2146773085-903363285-719344707-1375029G:S-1-5-21-2146773085-903363285-719344707-513D:(A;ID;FA;;;BA)(A;OICIIOID;GA;;;BA)(A;ID;FA;;;SY)(A;OICIIOID;GA;;;SY)(A;ID;0x1301bf;;;AU)(A;OICIIOID;SDGXGWGR;;;AU)(A;ID;0x1200a9;;;BU)(A;OICIIOID;GXGR;;;BU)";
             CancellationTokenSource tokenSource = new CancellationTokenSource();

--- a/test/DMLibTest/Cases/SMBPropertiesTest.cs
+++ b/test/DMLibTest/Cases/SMBPropertiesTest.cs
@@ -592,12 +592,10 @@ namespace DMLibTest.Cases
         public void TestNotsupportedPlatform()
         {
             Exception exception = null;
+            DownloadDirectoryOptions downloadDirectoryOptions = new DownloadDirectoryOptions();
             try
             {
-                DownloadDirectoryOptions downloadDirectoryOptions = new DownloadDirectoryOptions()
-                {
-                    PreserveSMBAttributes = true,
-                };
+                downloadDirectoryOptions.PreserveSMBAttributes = true;
             }
             catch (Exception ex)
             {
@@ -609,10 +607,20 @@ namespace DMLibTest.Cases
             exception = null;
             try
             {
-                UploadDirectoryOptions uploadDirectoryOptions = new UploadDirectoryOptions()
-                {
-                    PreserveSMBAttributes = true,
-                };
+                downloadDirectoryOptions.PreserveSMBPermissions = PreserveSMBPermissions.Owner;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            ValidateExceptionForParemterSetting(exception);
+
+            exception = null;
+            UploadDirectoryOptions uploadDirectoryOptions = new UploadDirectoryOptions();
+            try
+            {
+                uploadDirectoryOptions.PreserveSMBAttributes = true;
             }
             catch (Exception ex)
             {
@@ -624,10 +632,20 @@ namespace DMLibTest.Cases
             exception = null;
             try
             {
-                DownloadOptions downloadOptions = new DownloadOptions()
-                {
-                    PreserveSMBAttributes = true,
-                };
+                uploadDirectoryOptions.PreserveSMBPermissions = PreserveSMBPermissions.Owner;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            ValidateExceptionForParemterSetting(exception);
+
+            exception = null;
+            DownloadOptions downloadOptions = new DownloadOptions();
+            try
+            {
+                downloadOptions.PreserveSMBAttributes = true;
             }
             catch (Exception ex)
             {
@@ -639,10 +657,31 @@ namespace DMLibTest.Cases
             exception = null;
             try
             {
-                UploadOptions uploadOptions = new UploadOptions()
-                {
-                    PreserveSMBAttributes = true,
-                };
+                downloadOptions.PreserveSMBPermissions = PreserveSMBPermissions.Owner;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            ValidateExceptionForParemterSetting(exception);
+
+            exception = null;
+            UploadOptions uploadOptions = new UploadOptions();
+            try
+            {
+                uploadOptions.PreserveSMBAttributes = true;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            ValidateExceptionForParemterSetting(exception);
+
+            try
+            {
+                uploadOptions.PreserveSMBPermissions = PreserveSMBPermissions.Owner;
             }
             catch (Exception ex)
             {
@@ -746,6 +785,7 @@ namespace DMLibTest.Cases
         public void TestPreserveSMBPermissions()
         {
             if (!CrossPlatformHelpers.IsWindows) return;
+
             try
             {
                 PreserveSMBPermissions preserveSMBPermissions = 

--- a/test/DMLibTest/Cases/SetAttributesTest.cs
+++ b/test/DMLibTest/Cases/SetAttributesTest.cs
@@ -78,6 +78,8 @@ namespace DMLibTest.Cases
 #else
         private const string TestContentType = "newtype";
 #endif
+        private const string TestContentLanguage = "testlanguage";
+
         private const string invalidMD5 = "ThisIsAnInvalidMD5MD5A==";
         
         private static readonly string StraightALongString = new string('a', 1024);
@@ -159,18 +161,18 @@ namespace DMLibTest.Cases
         [DMLibTestMethod(DMLibDataType.CloudBlob, DMLibCopyMethod.ServiceSideSyncCopy)]
         public void TestSetAttributes()
         {
-            Dictionary<string, string> metadata = new Dictionary<string, string>();
-            if (DMLibTestContext.SourceType != DMLibDataType.Local)
-            {
-                metadata.Add("foo", "bar");
-            }
-
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);
             FileNode fileNode = new FileNode(DMLibTestBase.FileName)
             {
-                SizeInByte = DMLibTestBase.FileSizeInKB * 1024L, 
-                Metadata = metadata
+                SizeInByte = DMLibTestBase.FileSizeInKB * 1024L
             };
+
+            if (DMLibTestContext.SourceType != DMLibDataType.Local)
+            {
+                fileNode.Metadata = new Dictionary<string, string>();
+                fileNode.Metadata.Add("foo", "bar");
+                fileNode.ContentLanguage = SetAttributesTest.TestContentLanguage;
+            }
 
             sourceDataInfo.RootNode.AddFileNode(fileNode);
 
@@ -202,6 +204,11 @@ namespace DMLibTest.Cases
 
             FileNode destFileNode = result.DataInfo.RootNode.GetFileNode(DMLibTestBase.FileName);
             Test.Assert(TestContentType.Equals(destFileNode.ContentType), "Verify content type: {0}, expected {1}", destFileNode.ContentType, TestContentType);
+
+            if (DMLibTestContext.SourceType != DMLibDataType.Local)
+            {
+                Test.Assert(SetAttributesTest.TestContentLanguage.Equals(destFileNode.ContentLanguage), "Verify ContentLanguage: {0}, expected {1}", destFileNode.ContentLanguage, SetAttributesTest.TestContentLanguage);
+            }
         }
 
         [TestCategory(Tag.Function)]
@@ -209,21 +216,21 @@ namespace DMLibTest.Cases
         [DMLibTestMethod(DMLibDataType.CloudBlob, DMLibCopyMethod.ServiceSideSyncCopy)]
         public void TestDirectorySetAttributes()
         {
-            Dictionary<string, string> metadata = new Dictionary<string, string>();
-            if (DMLibTestContext.SourceType != DMLibDataType.Local)
-            {
-                metadata.Add("foo", "bar");
-            }
-
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);
 
             for (int i = 0; i < 3; ++i)
             {
                 FileNode fileNode = new FileNode(DMLibTestBase.FileName + i)
                 {
-                    SizeInByte = DMLibTestBase.FileSizeInKB * 1024L, 
-                    Metadata = metadata
+                    SizeInByte = DMLibTestBase.FileSizeInKB * 1024L
                 };
+
+                if (DMLibTestContext.SourceType != DMLibDataType.Local)
+                {
+                    fileNode.Metadata = new Dictionary<string, string>();
+                    fileNode.Metadata.Add("foo", "bar");
+                    fileNode.ContentLanguage = SetAttributesTest.TestContentLanguage;
+                }
 
                 sourceDataInfo.RootNode.AddFileNode(fileNode);
             }
@@ -263,6 +270,11 @@ namespace DMLibTest.Cases
             foreach(FileNode destFileNode in result.DataInfo.EnumerateFileNodes())
             {
                 Test.Assert(TestContentType.Equals(destFileNode.ContentType), "Verify content type: {0}, expected {1}", destFileNode.ContentType, TestContentType);
+
+                if (DMLibTestContext.SourceType != DMLibDataType.Local)
+                {
+                    Test.Assert(SetAttributesTest.TestContentLanguage.Equals(destFileNode.ContentLanguage), "Verify ContentLanguage: {0}, expected {1}", destFileNode.ContentLanguage, SetAttributesTest.TestContentLanguage);
+                }
             }
         }
 

--- a/test/DMLibTest/DMLibTest.csproj
+++ b/test/DMLibTest/DMLibTest.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;BINARY_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;BINARY_SERIALIZATION;DMLIB_TEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -33,7 +33,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;BINARY_SERIALIZATION</DefineConstants>
+    <DefineConstants>TRACE;BINARY_SERIALIZATION;DMLIB_TEST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -95,6 +95,12 @@
   <ItemGroup>
     <Compile Include="..\..\lib\FileNativeMethods.cs">
       <Link>Framework\FileNativeMethods.cs</Link>
+    </Compile>
+    <Compile Include="..\..\lib\FileSecurityNativeMethods.cs">
+      <Link>Framework\FileSecurityNativeMethods.cs</Link>
+    </Compile>
+    <Compile Include="..\..\lib\FileSecurityOperations.cs">
+      <Link>Framework\FileSecurityOperations.cs</Link>
     </Compile>
     <Compile Include="..\..\lib\Interop\Interop.Windows.cs">
       <Link>Framework\Interop.Windows.cs</Link>

--- a/test/DMLibTest/DMLibTest.csproj
+++ b/test/DMLibTest/DMLibTest.csproj
@@ -56,14 +56,14 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.Blob, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Storage.Blob.11.1.0\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.Blob, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Storage.Blob.11.1.1\lib\net452\Microsoft.Azure.Storage.Blob.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.Common, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Storage.Common.11.1.0\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.Common, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Storage.Common.11.1.1\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.File, Version=11.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.Storage.File.11.1.0\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.File, Version=11.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Storage.File.11.1.1\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=1.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/DMLibTest/Framework/CloudFileDataAdaptor.cs
+++ b/test/DMLibTest/Framework/CloudFileDataAdaptor.cs
@@ -256,8 +256,9 @@ namespace DMLibTest
 
                 if (dirNode.CreationTime.HasValue) cloudFileDir.Properties.CreationTime = dirNode.CreationTime;
                 if (dirNode.LastWriteTime.HasValue) cloudFileDir.Properties.LastWriteTime = dirNode.LastWriteTime;
-
+                if (null != dirNode.PortableSDDL) cloudFileDir.FilePermission = dirNode.PortableSDDL;
                 cloudFileDir.SetProperties(HelperConst.DefaultFileOptions);
+
                 cloudFileDir.FetchAttributes(null, HelperConst.DefaultFileOptions);
 
                 dirNode.CreationTime = cloudFileDir.Properties.CreationTime;
@@ -346,6 +347,12 @@ namespace DMLibTest
                 cloudFile.SetProperties(options: HelperConst.DefaultFileOptions);
             }
 
+            if (null != fileNode.PortableSDDL)
+            {
+                cloudFile.FilePermission = fileNode.PortableSDDL;
+                cloudFile.SetProperties(options: HelperConst.DefaultFileOptions);
+            }
+
             if (null != fileNode.Metadata && fileNode.Metadata.Count > 0)
             {
                 cloudFile.Metadata.Clear();
@@ -426,6 +433,15 @@ namespace DMLibTest
             dirNode.CreationTime = cloudDir.Properties.CreationTime;
             dirNode.SMBAttributes = cloudDir.Properties.NtfsAttributes;
 
+            if (!string.IsNullOrEmpty(cloudDir.FilePermission))
+            {
+                dirNode.PortableSDDL = cloudDir.FilePermission;
+            }
+            else if (!string.IsNullOrEmpty(cloudDir.Properties.FilePermissionKey))
+            {
+                dirNode.PortableSDDL = cloudDir.Share.GetFilePermission(cloudDir.Properties.FilePermissionKey, options: HelperConst.DefaultFileOptions);
+            }
+
             if (cloudDir.Metadata.Count > 0)
             {
                 dirNode.Metadata = new Dictionary<string, string>(cloudDir.Metadata);
@@ -468,6 +484,15 @@ namespace DMLibTest
             fileNode.LastWriteTime = cloudFile.Properties.LastWriteTime;
             fileNode.CreationTime = cloudFile.Properties.CreationTime;
             fileNode.SMBAttributes = cloudFile.Properties.NtfsAttributes;
+
+            if (!string.IsNullOrEmpty(cloudFile.FilePermission))
+            {
+                fileNode.PortableSDDL = cloudFile.FilePermission;
+            }
+            else if (!string.IsNullOrEmpty(cloudFile.Properties.FilePermissionKey))
+            {
+                fileNode.PortableSDDL = cloudFile.Share.GetFilePermission(cloudFile.Properties.FilePermissionKey, options: HelperConst.DefaultFileOptions);
+            }
 
             DateTimeOffset dateTimeOffset = (DateTimeOffset)cloudFile.Properties.LastModified;
             fileNode.LastModifiedTime = dateTimeOffset.UtcDateTime;

--- a/test/DMLibTest/Framework/DMLibDataInfo.cs
+++ b/test/DMLibTest/Framework/DMLibDataInfo.cs
@@ -163,6 +163,12 @@ namespace DMLibTest
             set;
         }
 
+        public string PortableSDDL
+        {
+            get;
+            set;
+        }
+
         public IDictionary<string, string> Metadata
         {
             get;
@@ -373,6 +379,12 @@ namespace DMLibTest
         }
 
         public DateTimeOffset? LastWriteTime
+        {
+            get;
+            set;
+        }
+
+        public string PortableSDDL
         {
             get;
             set;

--- a/test/DMLibTest/Framework/LongPathFileStreamExtension.cs
+++ b/test/DMLibTest/Framework/LongPathFileStreamExtension.cs
@@ -366,12 +366,21 @@ namespace DMLibTest.Framework
 #endif
             )
         {
-            path = LongPath.ToUncPath(path);
 #if DOTNET5_4
             LongPathFile.GetFileProperties(path, out creationTime, out lastWriteTime, out fileAttributes, isDirectory);
 #else
             LongPathFile.GetFileProperties(path, out creationTime, out lastWriteTime, out fileAttributes);
 #endif
+        }
+
+        public static string GetFilePortableSDDL(string path, PreserveSMBPermissions preserveSMBPermissions)
+        {
+            return FileSecurityOperations.GetFilePortableSDDL(path, preserveSMBPermissions);
+        }
+
+        public static void SetFileSecurityInfo(string path, string portableSDDL, PreserveSMBPermissions preserveSMBPermissions)
+        {
+            FileSecurityOperations.SetFileSecurity(path, portableSDDL, preserveSMBPermissions);
         }
     }
 }

--- a/test/DMLibTest/Util/Helpers.cs
+++ b/test/DMLibTest/Util/Helpers.cs
@@ -142,22 +142,22 @@ namespace DMLibTest
             string[] sourcesddlStrings = GetSDDLStringsForAllTypes(sourceSDDL);
             string[] destsddlStrings = GetSDDLStringsForAllTypes(destSDDL);
 
-            if ((preserveSMBPermissions & PreserveSMBPermissions.PreserveOwnerPermission) == PreserveSMBPermissions.PreserveOwnerPermission)
+            if ((preserveSMBPermissions & PreserveSMBPermissions.Owner) == PreserveSMBPermissions.Owner)
             {
                 Test.Assert(string.Equals(sourcesddlStrings[0], destsddlStrings[0]), "SDDL Value should  be expected.");
             }
 
-            if ((preserveSMBPermissions & PreserveSMBPermissions.PreserveGroupPermission) == PreserveSMBPermissions.PreserveGroupPermission)
+            if ((preserveSMBPermissions & PreserveSMBPermissions.Group) == PreserveSMBPermissions.Group)
             {
                 Test.Assert(string.Equals(sourcesddlStrings[1], destsddlStrings[1]), "SDDL Value should  be expected.");
             }
 
-            if ((preserveSMBPermissions & PreserveSMBPermissions.PreserveDACLPermission) == PreserveSMBPermissions.PreserveDACLPermission)
+            if ((preserveSMBPermissions & PreserveSMBPermissions.DACL) == PreserveSMBPermissions.DACL)
             {
                 Test.Assert(string.Equals(sourcesddlStrings[2], destsddlStrings[2]), "SDDL Value should  be expected.");
             }
 
-            if ((preserveSMBPermissions & PreserveSMBPermissions.PreserveSACLPermission) == PreserveSMBPermissions.PreserveSACLPermission)
+            if ((preserveSMBPermissions & PreserveSMBPermissions.SACL) == PreserveSMBPermissions.SACL)
             {
                 Test.Assert(string.Equals(sourcesddlStrings[3], destsddlStrings[3]), "SDDL Value should  be expected.");
             }

--- a/test/DMLibTest/app.config
+++ b/test/DMLibTest/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.Storage.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.1.0.0" newVersion="11.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.1.1.0" newVersion="11.1.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/DMLibTest/packages.config
+++ b/test/DMLibTest/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.Storage.Blob" version="11.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.Common" version="11.1.0" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.File" version="11.1.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Blob" version="11.1.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.Common" version="11.1.1" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.File" version="11.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.ComponentModel.EventBasedAsync" version="4.0.11" targetFramework="net45" />

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -19,14 +19,14 @@
     <dependencies>
       <group targetFramework="net452">
         <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" />
-        <dependency id="Microsoft.Azure.Storage.File" version="11.1.0" />
-        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" />
+        <dependency id="Microsoft.Azure.Storage.File" version="11.1.1" />
+        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.1" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Mono.Posix.NETStandard" version="1.0.0-beta2" />
         <dependency id="NETStandard.Library" version="2.0.1" />
-        <dependency id="Microsoft.Azure.Storage.File" version="11.1.0" />
-        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.0" />
+        <dependency id="Microsoft.Azure.Storage.File" version="11.1.1" />
+        <dependency id="Microsoft.Azure.Storage.Blob" version="11.1.1" />
         <dependency id="System.Runtime.Serialization.Xml" version="4.3.0" />
         <dependency id="System.Threading.ThreadPool" version="4.3.0" />
       </group>

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
1.  Add support to preserve SMB permission
2.  Reduce request to get copy state if ServiceSideAsyncCopy is when StartCopy method returns.
3. Remove local file length limitation checking when destination is Azure File.