### PR TITLE
Add file metadata when uploading to BLOB

### DIFF
--- a/lib/TransferControllers/TransferWriters/BlockBlobWriter.cs
+++ b/lib/TransferControllers/TransferWriters/BlockBlobWriter.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
                         transferData.Stream = new ChunkedMemoryStream(transferData.MemoryBuffer, 0, transferData.Length);
                     }
 
-                    Utils.SetAttributes(this.blockBlob, this.SharedTransferData.Attributes);
+                    Utils.SetAttributes(this.blockBlob, this.SharedTransferData);
 
                     await this.Controller.SetCustomAttributesAsync(this.blockBlob);
 

--- a/lib/TransferJobs/DirectoryTransfer.cs
+++ b/lib/TransferJobs/DirectoryTransfer.cs
@@ -439,6 +439,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             TransferLocation destLocation = GetDestinationTransferLocation(this.Destination, entry);
             var transferMethod = IsDummyCopy(entry) ? TransferMethod.DummyCopy : this.TransferMethod;
             SingleObjectTransfer transfer = new SingleObjectTransfer(sourceLocation, destLocation, transferMethod);
+            transfer.AddFileMetadata = this.AddFileMetadata;
             transfer.PreserveSMBAttributes = this.PreserveSMBAttributes;
             transfer.PreserveSMBPermissions = this.PreserveSMBPermissions;
             transfer.Context = this.Context;
@@ -481,6 +482,7 @@ namespace Microsoft.Azure.Storage.DataMovement
         {
             DirectoryTransfer.UpdateCredentials(this.Source, transfer.Source);
             DirectoryTransfer.UpdateCredentials(this.Destination, transfer.Destination);
+            transfer.AddFileMetadata = this.AddFileMetadata;
             transfer.PreserveSMBAttributes = this.PreserveSMBAttributes;
             transfer.PreserveSMBPermissions = this.PreserveSMBPermissions;
         }

--- a/lib/TransferJobs/Transfer.cs
+++ b/lib/TransferJobs/Transfer.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Azure.Storage.DataMovement
             this.TransferMethod = other.TransferMethod;
             this.OriginalFormatVersion = other.OriginalFormatVersion;
             this.PreserveSMBAttributes = other.PreserveSMBAttributes;
+            this.AddFileMetadata = other.AddFileMetadata;
         }
 
         /// Used to ensure that deserialized transfers are only used
@@ -238,6 +239,12 @@ namespace Microsoft.Azure.Storage.DataMovement
         {
             get;
             set;
+        }
+
+        public bool AddFileMetadata
+        {
+	        get;
+	        set;
         }
 
         /// <summary>

--- a/lib/TransferManager.cs
+++ b/lib/TransferManager.cs
@@ -1587,10 +1587,11 @@ namespace Microsoft.Azure.Storage.DataMovement
             Transfer transfer = GetOrCreateSingleObjectTransfer(sourceLocation, destLocation, TransferMethod.SyncCopy, context);
 
             if ((null != uploadOptions)
-                && (destLocation.Type == TransferLocationType.AzureFile))
+                && (destLocation.Type == TransferLocationType.AzureFile || uploadOptions.AddFileMetadata))
             {
                 transfer.PreserveSMBAttributes = uploadOptions.PreserveSMBAttributes;
                 transfer.PreserveSMBPermissions = uploadOptions.PreserveSMBPermissions;
+                transfer.AddFileMetadata = uploadOptions.AddFileMetadata;
             }
 
             return DoTransfer(transfer, context, cancellationToken);
@@ -1638,10 +1639,11 @@ namespace Microsoft.Azure.Storage.DataMovement
 
                 transfer.BlobType = options.BlobType;
 
-                if (destLocation.Type == TransferLocationType.AzureFileDirectory)
+                if (destLocation.Type == TransferLocationType.AzureFileDirectory || options.AddFileMetadata)
                 {
                     transfer.PreserveSMBAttributes = options.PreserveSMBAttributes;
                     transfer.PreserveSMBPermissions = options.PreserveSMBPermissions;
+                    transfer.AddFileMetadata = options.AddFileMetadata;
                 }
             }
 

--- a/lib/TransferOptions/UploadDirectoryOptions.cs
+++ b/lib/TransferOptions/UploadDirectoryOptions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Storage.DataMovement
     public sealed class UploadDirectoryOptions : DirectoryOptions
     {
         private bool preserveSMBAttributes = false;
+        private bool addFileMetadata = false;
         private PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.None;
         private bool followSymlink = false;
 
@@ -45,6 +46,30 @@ namespace Microsoft.Azure.Storage.DataMovement
 
                 this.followSymlink = value;
             }
+        }
+
+        public bool AddFileMetadata
+        {
+	        get
+	        {
+		        return this.addFileMetadata;
+	        }
+
+	        set
+	        {
+#if DOTNET5_4
+                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+                else
+                {
+                    this.addFileMetadata = value;
+                }
+#else
+		        this.addFileMetadata = value;
+#endif
+	        }
         }
 
         /// <summary>

--- a/lib/TransferOptions/UploadOptions.cs
+++ b/lib/TransferOptions/UploadOptions.cs
@@ -16,12 +16,37 @@ namespace Microsoft.Azure.Storage.DataMovement
     public sealed class UploadOptions
     {
         private bool preserveSMBAttributes = false;
+        private bool addFileMetadata = false;
         private PreserveSMBPermissions preserveSMBPermissions = PreserveSMBPermissions.None;
 
         /// <summary>
         /// Gets or sets an <see cref="AccessCondition"/> object that represents the access conditions for the destination object. If <c>null</c>, no condition is used.
         /// </summary>
         public AccessCondition DestinationAccessCondition { get; set; }
+
+        public bool AddFileMetadata
+        {
+	        get
+	        {
+		        return this.addFileMetadata;
+	        }
+
+	        set
+	        {
+#if DOTNET5_4
+                if (value && !Interop.CrossPlatformHelpers.IsWindows)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+                else
+                {
+                    this.addFileMetadata = value;
+                }
+#else
+                this.addFileMetadata = value;
+#endif
+	        }
+        }
 
         /// <summary>
         /// Gets or sets a flag that indicates whether to preserve SMB attributes during uploading.

--- a/lib/Utils.cs
+++ b/lib/Utils.cs
@@ -602,6 +602,24 @@ namespace Microsoft.Azure.Storage.DataMovement
             }
         }
 
+        public static void SetAttributes(CloudBlob blob, SharedTransferData sharedTransferData)
+        {
+            SetAttributes(blob, sharedTransferData.Attributes);
+
+            if (sharedTransferData.TransferJob.Transfer.AddFileMetadata)
+            {
+	            blob.Metadata.Add("Origin", sharedTransferData.TransferJob.Source.Instance.ToString());
+	            blob.Metadata.Add(nameof(Attributes.LastWriteTime), sharedTransferData.Attributes.LastWriteTime.ToString());
+	            blob.Metadata.Add(nameof(Attributes.CreationTime), sharedTransferData.Attributes.CreationTime.ToString());
+	            blob.Metadata.Add(nameof(Attributes.PortableSDDL), sharedTransferData.Attributes.PortableSDDL);
+
+	            if (sharedTransferData.Attributes.CloudFileNtfsAttributes.HasValue)
+	            {
+		            blob.Metadata.Add(nameof(sharedTransferData.Attributes.CloudFileNtfsAttributes), sharedTransferData.Attributes.CloudFileNtfsAttributes.Value.ToString());
+	            }
+            }
+        }
+
         public static void SetAttributes(CloudFile file, Attributes attributes, bool preserveSMBProperties)
         {
             if (attributes.OverWriteAll)


### PR DESCRIPTION
Hi @EmmaZhu, @vinjiang,

This is a follow-up PR to our conversation today. It's very basic implementation to meet our #228 feature request.

I introduced new `AddFileMetadata` option for upload (both single file and directory). Based on it I'm adding file metadata to `CloudBlockBlob` metadata property, so I can then use it in `SetAttributesCallbackAsync`.