### PR TITLE
Fix the issue when ranges may be losted when copying page blob/file with ServiceSideSyncCopy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Microsoft Azure Storage Data Movement Library (2.0.0)
+# Microsoft Azure Storage Data Movement Library (2.0.1)
 
 The Microsoft Azure Storage Data Movement Library designed for high-performance uploading, downloading and copying Azure Storage Blob and File. This library is based on the core data movement framework that powers [AzCopy](https://azure.microsoft.com/documentation/articles/storage-use-azcopy/).
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+2020.11.20 Version 2.0.1
+ * All Service on both .Net Framework and .Net Core
+   - Fixed an issue which may cause data loss in copying with ServiceSideSyncCopy, when source and destination are both Page Blob or Azure File.
+
 2020.08.31 Version 2.0.0
  * All Service on both .Net Framework and .Net Core
    - Upgraded Microsoft.Azure.Storage.Blob from 11.1.2 to 11.2.2

--- a/lib/TransferControllers/ServiceSideSyncCopyControllers/RangeBasedServiceSideSyncCopy.cs
+++ b/lib/TransferControllers/ServiceSideSyncCopyControllers/RangeBasedServiceSideSyncCopy.cs
@@ -58,8 +58,6 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
         protected override async Task DoPreCopyAsync()
         {
             this.hasWork = false;
-            this.pagesToCopy = new List<long>();
-            this.pageListBag = new ConcurrentBag<List<long>>();
             long rangeSpanOffset = this.nextRangesSpanOffset;
             long rangeSpanLength = Math.Min(Constants.PageRangesSpanSize, this.SourceHandler.TotalLength - rangeSpanOffset);
 
@@ -95,6 +93,7 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
 
             if (this.getRangesCountdownEvent.Signal())
             {
+                this.pagesToCopy = new List<long>();
                 foreach (var pageListInARange in this.pageListBag)
                 {
                     this.pagesToCopy.AddRange(pageListInARange);
@@ -157,6 +156,7 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
                 {
                     int rangeSpanCount = (int)Math.Ceiling(((double)(this.SourceHandler.TotalLength - this.nextRangesSpanOffset)) / Constants.PageRangesSpanSize);
                     this.getRangesCountdownEvent = new CountdownEvent(rangeSpanCount);
+                    this.pageListBag = new ConcurrentBag<List<long>>();
                     this.state = State.PreCopy;
                 }
             }

--- a/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\lib\**\*.cs;..\..\tools\AssemblyInfo\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    <Compile Include="..\..\lib\**\*.cs;..\..\tools\AssemblyInfo\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**;..\..\lib\obj\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft.WindowsAzure.Storage.DataMovement Class Library</Description>
-    <Version>2.0.0.0</Version>
+    <Version>2.0.1.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/netcore/MsTestLib/MsTestLib.csproj
+++ b/netcore/MsTestLib/MsTestLib.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\test\MsTestLib\**\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    <Compile Include="..\..\test\MsTestLib\**\*.cs" Exclude="bin\**;obj\**;..\..\test\MsTestLib\obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/DataMovementSamples/DataMovementSamples.csproj
@@ -42,8 +42,8 @@
     <Reference Include="Microsoft.Azure.Storage.Common, Version=11.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.2.2\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=2.0.0.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.2.0.0\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.2.0.1\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Storage.File, Version=11.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Storage.File.11.2.2\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>

--- a/samples/DataMovementSamples/DataMovementSamples/packages.config
+++ b/samples/DataMovementSamples/DataMovementSamples/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Storage.Blob" version="11.2.2" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.Common" version="11.2.2" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="2.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="2.0.1" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.File" version="11.2.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />

--- a/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
+++ b/samples/DataMovementSamples/netcore/DataMovementSamples/DataMovementSamples.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="2.0.1" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
   </ItemGroup>
 

--- a/samples/PreserveFilePropertiesSamples/PreserveFilePropertiesSamples/PreserveFilePropertiesSamples.csproj
+++ b/samples/PreserveFilePropertiesSamples/PreserveFilePropertiesSamples/PreserveFilePropertiesSamples.csproj
@@ -42,8 +42,8 @@
     <Reference Include="Microsoft.Azure.Storage.Common, Version=11.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.2.2\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=2.0.0.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.2.0.0\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.2.0.1\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Storage.File, Version=11.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Storage.File.11.2.2\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>

--- a/samples/PreserveFilePropertiesSamples/PreserveFilePropertiesSamples/packages.config
+++ b/samples/PreserveFilePropertiesSamples/PreserveFilePropertiesSamples/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.Blob" version="11.2.2" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.Common" version="11.2.2" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="2.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="2.0.1" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.File" version="11.2.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />

--- a/samples/PreserveFilePropertiesSamples/netcore/PreserveFilePropertiesSamples.csproj
+++ b/samples/PreserveFilePropertiesSamples/netcore/PreserveFilePropertiesSamples.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="2.0.1" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>
 

--- a/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
+++ b/samples/S3ToAzureSample/S3ToAzureSample/S3ToAzureSample.csproj
@@ -50,8 +50,8 @@
     <Reference Include="Microsoft.Azure.Storage.Common, Version=11.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Storage.Common.11.2.2\lib\net452\Microsoft.Azure.Storage.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=2.0.0.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.2.0.0\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Storage.DataMovement, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Storage.DataMovement.2.0.1\lib\net452\Microsoft.Azure.Storage.DataMovement.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Storage.File, Version=11.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.Storage.File.11.2.2\lib\net452\Microsoft.Azure.Storage.File.dll</HintPath>

--- a/samples/S3ToAzureSample/S3ToAzureSample/packages.config
+++ b/samples/S3ToAzureSample/S3ToAzureSample/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Storage.Blob" version="11.2.2" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.Common" version="11.2.2" targetFramework="net452" />
-  <package id="Microsoft.Azure.Storage.DataMovement" version="2.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.Storage.DataMovement" version="2.0.1" targetFramework="net452" />
   <package id="Microsoft.Azure.Storage.File" version="11.2.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.8.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />

--- a/test/DMLibTest/Cases/BigFileTest.cs
+++ b/test/DMLibTest/Cases/BigFileTest.cs
@@ -70,10 +70,12 @@ namespace DMLibTest
             DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);
             DMLibDataHelper.AddMultipleFilesBigSize(sourceDataInfo.RootNode, DMLibTestBase.FileName);
 
-            var result = this.ExecuteTestCase(sourceDataInfo, new TestExecutionOptions<DMLibDataInfo>());
+            var option = new TestExecutionOptions<DMLibDataInfo>();
+            var result = this.ExecuteTestCase(sourceDataInfo, option);
 
             Test.Assert(result.Exceptions.Count == 0, "Verify no exception is thrown.");
             Test.Assert(DMLibDataHelper.Equals(sourceDataInfo, result.DataInfo), "Verify transfer result.");
+            this.ValidateDestinationMD5ByDownloading(result.DataInfo, option);
         }
     }
 }

--- a/test/DMLibTest/Cases/BigFileTest.cs
+++ b/test/DMLibTest/Cases/BigFileTest.cs
@@ -10,6 +10,7 @@ namespace DMLibTest
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using DMLibTestCodeGen;
+    using Microsoft.Azure.Storage.DataMovement;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using MS.Test.Common.MsTestLib;
 
@@ -67,15 +68,24 @@ namespace DMLibTest
         [DMLibTestMethodSet(DMLibTestMethodSet.AllValidDirection)]
         public void TransferBigSizeObject()
         {
-            DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);
-            DMLibDataHelper.AddMultipleFilesBigSize(sourceDataInfo.RootNode, DMLibTestBase.FileName);
+            int originParallel = TransferManager.Configurations.ParallelOperations;
+            TransferManager.Configurations.ParallelOperations = 4;
+            try
+            {
+                DMLibDataInfo sourceDataInfo = new DMLibDataInfo(string.Empty);
+                DMLibDataHelper.AddMultipleFilesBigSize(sourceDataInfo.RootNode, DMLibTestBase.FileName);
 
-            var option = new TestExecutionOptions<DMLibDataInfo>();
-            var result = this.ExecuteTestCase(sourceDataInfo, option);
+                var option = new TestExecutionOptions<DMLibDataInfo>();
+                var result = this.ExecuteTestCase(sourceDataInfo, option);
 
-            Test.Assert(result.Exceptions.Count == 0, "Verify no exception is thrown.");
-            Test.Assert(DMLibDataHelper.Equals(sourceDataInfo, result.DataInfo), "Verify transfer result.");
-            this.ValidateDestinationMD5ByDownloading(result.DataInfo, option);
+                Test.Assert(result.Exceptions.Count == 0, "Verify no exception is thrown.");
+                Test.Assert(DMLibDataHelper.Equals(sourceDataInfo, result.DataInfo), "Verify transfer result.");
+                this.ValidateDestinationMD5ByDownloading(result.DataInfo, option);
+            }
+            finally
+            {
+                TransferManager.Configurations.ParallelOperations = originParallel;
+            }
         }
     }
 }

--- a/test/DMLibTest/Cases/BigFileTest.cs
+++ b/test/DMLibTest/Cases/BigFileTest.cs
@@ -80,7 +80,11 @@ namespace DMLibTest
 
                 Test.Assert(result.Exceptions.Count == 0, "Verify no exception is thrown.");
                 Test.Assert(DMLibDataHelper.Equals(sourceDataInfo, result.DataInfo), "Verify transfer result.");
-                this.ValidateDestinationMD5ByDownloading(result.DataInfo, option);
+
+                if (!(DMLibTestContext.DestType == DMLibDataType.Local || DMLibTestContext.DestType == DMLibDataType.Stream))
+                {
+                    this.ValidateDestinationMD5ByDownloading(result.DataInfo, option);
+                }
             }
             finally
             {

--- a/test/DMLibTest/Framework/DMLibDataHelper.cs
+++ b/test/DMLibTest/Framework/DMLibDataHelper.cs
@@ -88,7 +88,7 @@ namespace DMLibTest
 
         public static void AddMultipleFilesBigSize(DirNode dirNode, string filePrefix)
         {
-            int[] fileSizes = new int[] { 32000, 64 * 1024 };
+            int[] fileSizes = new int[] { 32000, 64 * 1024, 257 * 1024,  1024 * 1024};
             AddMultipleFilesDifferentSize(dirNode, filePrefix, fileSizes);
         }
 

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
Fix the issue when ranges may be losted when copying page blob/file with ServiceSideSyncCopy.
Fix a build issue which is caused by compiling a build intermediate file. // This is to exclude the build intermediate  cs file to avoid build failure.
