### PR TITLE
Make TransferRequest timeouts editable with reflection

### DIFF
--- a/lib/Transfer_RequestOptions.cs
+++ b/lib/Transfer_RequestOptions.cs
@@ -31,16 +31,16 @@ namespace Microsoft.Azure.Storage.DataMovement
         /// <summary>
         /// Stores the default maximum execution time across all potential retries. 
         /// </summary>
-        private static readonly TimeSpan DefaultMaximumExecutionTime =
+        private static TimeSpan DefaultMaximumExecutionTime =
             TimeSpan.FromSeconds(900);
 
         /// <summary>
         /// Stores the default server timeout.
         /// </summary>
-        private static readonly TimeSpan DefaultServerTimeout =
+        private static TimeSpan DefaultServerTimeout =
             TimeSpan.FromSeconds(300);
 
-        public static readonly TimeSpan DefaultCreationServerTimeout =
+        public static TimeSpan DefaultCreationServerTimeout =
             TimeSpan.FromSeconds(30);
 
         /// <summary>


### PR DESCRIPTION
I am a Relativity engineer, we are using Data Movement library to transfer huge portions of data. We experience failures for slower networks and bigger files. We were able to solve this by overriding those timeouts with reflection, unfortunately this doesn't work on .net core as those properties are marked 'readonly'. Alternatively I could make this properly and expose those parameters to client, although for our usecase this is sufficient.