### PR TITLE
REL-610971 not valid file paths are reported as a skipped file when i…

### DIFF
--- a/lib/DataMovement.csproj
+++ b/lib/DataMovement.csproj
@@ -88,6 +88,7 @@
     <Compile Include="ChunkedMemoryStream.cs" />
     <Compile Include="CopyMethod.cs" />
     <Compile Include="DirectoryListingScheduler.cs" />
+    <Compile Include="Exceptions\TransferInvalidPathException.cs" />
     <Compile Include="Extensions\StorageCopyState.cs" />
     <Compile Include="FileNativeMethods.cs" />
     <Compile Include="FileSecurityNativeMethods.cs" />

--- a/lib/Exceptions/TransferErrorCode.cs
+++ b/lib/Exceptions/TransferErrorCode.cs
@@ -125,5 +125,10 @@ namespace Microsoft.Azure.Storage.DataMovement
         /// Uncategorized transfer error.
         /// </summary>
         Unknown = 32,
-    }
+
+        /// <summary>
+        /// Fails to validate source.
+        /// </summary>
+        FailToValidateSource = 33,
+	}
 }

--- a/lib/Exceptions/TransferInvalidPathException.cs
+++ b/lib/Exceptions/TransferInvalidPathException.cs
@@ -1,0 +1,61 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="TransferInvalidPathException.cs" company="Microsoft">
+//    Copyright (c) Microsoft Corporation
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Storage.DataMovement
+{
+	using System;
+	using System.Runtime.Serialization;
+
+	/// <summary>
+	/// Exceptions thrown when transfer skips.
+	/// </summary>
+#if BINARY_SERIALIZATION
+	[Serializable]
+#else
+    [DataContract]
+#endif // BINARY_SERIALIZATION
+	public class TransferInvalidPathException : TransferException
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TransferInvalidPathException" /> class.
+		/// </summary>
+		public TransferInvalidPathException()
+			: base(TransferErrorCode.FailToValidateSource)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TransferInvalidPathException" /> class.
+		/// </summary>
+		/// <param name="errorMessage">The message that describes the error.</param>
+		public TransferInvalidPathException(string errorMessage)
+			: base(TransferErrorCode.FailToValidateSource, errorMessage)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TransferInvalidPathException" /> class.
+		/// </summary>
+		/// <param name="errorMessage">Exception message.</param>
+		/// <param name="innerException">Inner exception.</param>
+		public TransferInvalidPathException(string errorMessage, Exception innerException)
+			: base(TransferErrorCode.FailToValidateSource, errorMessage, innerException)
+		{
+		}
+
+#if BINARY_SERIALIZATION
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TransferInvalidPathException" /> class.
+		/// </summary>
+		/// <param name="info">Serialization information.</param>
+		/// <param name="context">Streaming context.</param>
+		protected TransferInvalidPathException(SerializationInfo info, StreamingContext context)
+			: base(info, context)
+		{
+		}
+#endif // BINARY_SERIALIZATION
+	}
+}

--- a/lib/TransferCallbacks.cs
+++ b/lib/TransferCallbacks.cs
@@ -5,8 +5,7 @@
 //------------------------------------------------------------------------------
 namespace Microsoft.Azure.Storage.DataMovement
 {
-    using System;
-    using System.Threading.Tasks;
+	using System.Threading.Tasks;
 
     /// <summary>
     /// Callback invoked to tell whether to overwrite an existing destination.
@@ -35,4 +34,11 @@ namespace Microsoft.Azure.Storage.DataMovement
     /// <param name="source">Source instance in the transfer.</param>
     /// <param name="destination">Instance of destination to be overwritten.</param>
     public delegate Task SetAttributesCallbackAsync(object source, object destination);
+
+    /// <summary>
+    /// Callback invoked to tell whether a path is valid.
+    /// </summary>
+    /// <param name="source">Instance of the transfer source.</param>
+    /// <returns>True if the source of transfer is valid; otherwise false.</returns>
+    public delegate Task<bool> IsPathValidAsync(object source);
 }

--- a/lib/TransferContext.cs
+++ b/lib/TransferContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Storage.DataMovement
         {
             return true;
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TransferContext" /> class.
         /// </summary>
@@ -123,6 +123,14 @@ namespace Microsoft.Azure.Storage.DataMovement
             get;
             set;
         }
+
+
+        public IsPathValidAsync IsSourcePathValidAsync
+        {
+            get;
+            set;
+        }
+
 
         /// <summary>
         /// Gets or sets the progress update handler.

--- a/lib/TransferControllers/SyncTransferController.cs
+++ b/lib/TransferControllers/SyncTransferController.cs
@@ -144,6 +144,16 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
                 }
             }
 
+            if (this.TransferJob.Transfer.ShouldValidateSource)
+            {
+	            var sourcePath = this.TransferJob.Source.Instance;
+	            var isValid = await IsSourcePathValidAsync(sourcePath);
+	            if (!isValid)
+	            {
+		            throw new TransferInvalidPathException();
+	            }
+            }
+            
             if (!this.reader.PreProcessed && this.reader.HasWork)
             {
                 await this.reader.DoWorkInternalAsync();
@@ -163,6 +173,17 @@ namespace Microsoft.Azure.Storage.DataMovement.TransferControllers
         protected override void SetErrorState(Exception ex)
         {
             this.ErrorOccurred = true;
+        }
+
+
+        private async Task<bool> IsSourcePathValidAsync(object source)
+        {
+	        if (null != this.TransferContext && null != this.TransferContext.IsSourcePathValidAsync)
+	        {
+		        return await this.TransferContext.IsSourcePathValidAsync(source);
+	        }
+
+	        return true;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]

--- a/lib/TransferJobs/SingleObjectTransfer.cs
+++ b/lib/TransferJobs/SingleObjectTransfer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Storage.DataMovement
         private TransferJob transferJob;
 
         private bool shouldTransferChecked = false;
-
+        private bool shouldValidateSource = true;
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleObjectTransfer"/> class.
         /// This constructor will check whether source and destination is valid for the operation:
@@ -166,6 +166,20 @@ namespace Microsoft.Azure.Storage.DataMovement
             }
         }
 
+        public bool ShouldValidateSource
+        {
+	        get
+	        {
+		        return this.shouldValidateSource;
+	        }
+
+	        set
+	        {
+		        this.shouldValidateSource = value;
+
+	        }
+        }
+
         public AzureFileDirectorySDDLCache SDDLCache
         {
             get;
@@ -236,9 +250,10 @@ namespace Microsoft.Azure.Storage.DataMovement
                 eventArgs.EndTime = DateTime.UtcNow;
                 eventArgs.Exception = exception;
 
-                if (exception.ErrorCode == TransferErrorCode.NotOverwriteExistingDestination)
+                if (exception.ErrorCode == TransferErrorCode.NotOverwriteExistingDestination 
+                    || exception.ErrorCode == TransferErrorCode.FailToValidateSource)
                 {
-                    // transfer skipped
+                    // transfer skipped due to either already existing on destination side or source path does not meet validation
                     this.UpdateTransferJobStatus(this.transferJob, TransferJobStatus.Skipped);
                     if (this.Context != null)
                     {


### PR DESCRIPTION
Exposed IsPathValidAsync callback through the TransferContext so customer I able to inject own code to perform validation.
Given callback is executed by SyncTransferController which is responsible for processing each chunk of file being transferred.
Given callback is executed only when set. When it is null no execution it means that no validation at all
Only source path is being validated.
When IsPathValidAsync returns true given chunk of data is being processed otherwise  TransferInvalidPathException is thrown and additionally total number of skipped files is incremented. Given path is reported through FileSkipped event 