### PR TITLE
{AzureStorage} fixes Azure/azure-sdk-for-net#31647

### DIFF
--- a/lib/TransferCallbacks.cs
+++ b/lib/TransferCallbacks.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Storage.DataMovement
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Callback invoked to tell whether to overwrite an existing destination.
+    /// Callback invoked to check whether to overwrite an existing destination.
     /// </summary>
     /// <param name="source">Instance of source used to overwrite the destination.</param>
     /// <param name="destination">Instance of destination to be overwritten.</param>


### PR DESCRIPTION
fixes Azure/azure-sdk-for-net#31647

Docs Link: https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.storage.datamovement.shouldtransfercallbackasync?view=azure-dotnet

Description needs to be updated from "Callback invoked to tell whether a transfer should be done" to "Callback invoked to check whether a transfer should be done"