### PR TITLE
Added Systems.Text.RegularExpressions as a dependency for stable version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+2024.05.08 Version 2.0.5
+ * Added Systems.Text.RegularExpressions as a dependency and targetted the most stable version 4.3.1
+
 2021.05.12 Version 2.0.4
  * Resolves issue of pointing to incorrect version of Microsoft.Azure.Storage.Blob and File libraries
  * Upgraded to Microsoft.Azure.Storage.Blob to 11.2.3

--- a/lib/packages.config
+++ b/lib/packages.config
@@ -10,4 +10,5 @@
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net45" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net452" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Resolving vulnerability where  Systems.Text.RegularExpressions is unstable, and upgrading to the most stable version 4.3.1