### PR TITLE
Bumping version to 2.0.5 and cleanup after release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-2021.05.12 Version 2.0.4
+2021.05.12 Version 2.0.5
  * Resolves issue of pointing to incorrect version of Microsoft.Azure.Storage.Blob and File libraries
  * Upgraded to Microsoft.Azure.Storage.Blob to 11.2.3
  * Upgraded to Microsoft.Azure.Storage.File to 11.2.3

--- a/netcore/DMLibTest/DMLibTest.csproj
+++ b/netcore/DMLibTest/DMLibTest.csproj
@@ -33,8 +33,8 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.0.4" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
-    <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.2.2" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
+    <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.2.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
+++ b/netcore/Microsoft.Azure.Storage.DataMovement/Microsoft.Azure.Storage.DataMovement.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Microsoft.WindowsAzure.Storage.DataMovement Class Library</Description>
-    <Version>2.0.4.0</Version>
+    <Description>Microsoft.Azure.Storage.DataMovement Class Library</Description>
+    <Version>2.0.5.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -11,7 +11,7 @@
     <AssemblyName>Microsoft.Azure.Storage.DataMovement</AssemblyName>
     <AssemblyOriginatorKeyFile>../../tools/strongnamekeys/fake/windows.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PackageId>Microsoft.WindowsAzure.Storage.DataMovement</PackageId>
+    <PackageId>Microsoft.Azure.Storage.DataMovement</PackageId>
     <AssetTargetFallback>$(AssetTargetFallback);dnxcore50;portable-net451+win8</AssetTargetFallback>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -39,9 +39,10 @@
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="2.0.4" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.2.3" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0-beta2" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.6.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
   </ItemGroup>
 

--- a/tools/AssemblyInfo/SharedAssemblyInfo.cs
+++ b/tools/AssemblyInfo/SharedAssemblyInfo.cs
@@ -12,12 +12,12 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("2.0.4.0")]
-[assembly: AssemblyFileVersion("2.0.4.0")]
+[assembly: AssemblyVersion("2.0.5.0")]
+[assembly: AssemblyFileVersion("2.0.5.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure Storage")]
-[assembly: AssemblyCopyright("Copyright © 2019 Microsoft Corp.")]
+[assembly: AssemblyCopyright("Copyright © 2024 Microsoft Corp.")]
 [assembly: AssemblyTrademark("Microsoft ® is a registered trademark of Microsoft Corporation.")]
 [assembly: AssemblyCulture("")]
 

--- a/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
+++ b/tools/nupkg/Microsoft.Azure.Storage.DataMovement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.12">
     <id>Microsoft.Azure.Storage.DataMovement</id>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
     <title>Microsoft Azure Storage Data Movement Library</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -23,13 +23,14 @@
         <dependency id="Microsoft.Azure.Storage.Blob" version="11.2.3" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Mono.Posix.NETStandard" version="1.0.0-beta2" />
+        <dependency id="Mono.Posix.NETStandard" version="1.0.0" />
         <dependency id="NETStandard.Library" version="2.0.1" />
         <dependency id="Microsoft.Azure.Storage.File" version="11.2.3" />
         <dependency id="Microsoft.Azure.Storage.Blob" version="11.2.3" />
         <dependency id="System.Runtime.Serialization.Xml" version="4.3.0" />
         <dependency id="System.Threading.ThreadPool" version="4.3.0" />
         <dependency id="System.Net.Http" version="4.3.4" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.1" />
       </group>
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
- Bump version from 2.0.4 to 2.0.5
- Cleanup to ensure tests are using the most stable version of System.Text.RegularExpressions
- Fixing typos
- Fixing some tests dependencies